### PR TITLE
user can now specify max_tree_depth to NUTS from config

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -517,6 +517,13 @@ PARAMETERS = [
         # "validate": do_nothing,
         "type": lambda lst: IntEnum("enum", lst, start=0),
     },
+    {
+        "name": "MAX_TREE_DEPTH",
+        "validate": [
+            partial(test_type, tested_type=(int)),
+            test_positive,
+        ],
+    },
 ]
 
 

--- a/mechanistic_model/mechanistic_inferer.py
+++ b/mechanistic_model/mechanistic_inferer.py
@@ -49,11 +49,13 @@ class MechanisticInferer(AbstractParameters):
             )
 
         if inferer_type == "mcmc":
+            # default to max tree depth of 5 if not specified
+            tree_depth = getattr(self.config, "MAX_TREE_DEPTH", 5)
             self.inference_algo = MCMC(
                 NUTS(
                     self.likelihood,
                     dense_mass=True,
-                    max_tree_depth=5,
+                    max_tree_depth=tree_depth,
                     init_strategy=numpyro.infer.init_to_median,
                 ),
                 num_warmup=self.config.INFERENCE_NUM_WARMUP,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,29 @@ def test_negative_initial_infections():
         Config(input_json)
 
 
+def test_negative_tree_depth():
+    input_json = """{"MAX_TREE_DEPTH": -1}"""
+    with pytest.raises(AssertionError):
+        Config(input_json)
+
+
+def test_zero_tree_depth():
+    input_json = """{"MAX_TREE_DEPTH": 0}"""
+    with pytest.raises(AssertionError):
+        Config(input_json)
+
+
+def test_float_tree_depth():
+    input_json = """{"MAX_TREE_DEPTH": 1.2}"""
+    with pytest.raises(AssertionError):
+        Config(input_json)
+
+
+def test_valid_tree_depth():
+    input_json = """{"MAX_TREE_DEPTH": 10}"""
+    assert Config(input_json).MAX_TREE_DEPTH == 10
+
+
 def test_str_initial_infections():
     input_json = """{"INITIAL_INFECTIONS": "5"}"""
     with pytest.raises(AssertionError):


### PR DESCRIPTION
using the MAX_TREE_DEPTH parameter in a config file, the user can now specify to the NUTS sampler the max tree depth to address issue: #59 