### PR TITLE
can now load contact matricies for different states not just USA

### DIFF
--- a/mechanistic_model/abstract_parameters.py
+++ b/mechanistic_model/abstract_parameters.py
@@ -245,4 +245,4 @@ class AbstractParameters:
             self.config.NUM_AGE_GROUPS,
             self.config.AGE_LIMITS[0],
             self.config.AGE_LIMITS,
-        )["United States"]["avg_CM"]
+        )[self.config.REGIONS[0]]["avg_CM"]


### PR DESCRIPTION
this functionality was always available but was unsure whether or not it would explode other features. It does work just fine to modify config.REGIONS and both the census data and the contact matricies are loaded correctly.