### PR TITLE
config now validates distributions and catches invalid supports

### DIFF
--- a/config/config_inferer_covid.json
+++ b/config/config_inferer_covid.json
@@ -22,7 +22,11 @@
                     "transform": "AffineTransform",
                     "params": {
                         "loc": 2.5,
-                        "scale": 1
+                        "scale": 1,
+                        "domain": {
+                            "constraint": "unit_interval",
+                            "params": {}
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The `config.py` script will now check if a distribution is being passed in and do meaningful checks on the support of the distribution. What this means for users is that you can no longer specify something like an unbounded Normal distribution as a prior for `INFECTIOUS_PERIOD`, because `Normal(0,1)` has support over the entire number line, and can therefore produce samples that are negative and not valid infectious periods. Users must now specify the support of their Distributions and Transforms if they are not implicit.

Something like a `TruncatedNormal(loc=5, scale=1, low=1)` has support from 1-> inf, and will pass a test like `test_not_negative()` but a `TransformedDistribution(base_dist=TruncatedNormal(loc=5, scale=1, low=1), transforms=AffineTransform(loc=1, scale=1))` which uses the same `TruncatedNormal` will not unless the domain is also specified in the Transform.

```
TransformedDistribution(
    base_dist=TruncatedNormal(loc=5, scale=1, low=1), 
    transforms=AffineTransform(loc=1, scale=1)
)
``` 
fails

```
TransformedDistribution(
    base_dist=TruncatedNormal(loc=5, scale=1, low=1), 
    transforms=AffineTransform(loc=1, scale=1, constraints=greater_than(lower_bound=1)))
)
```
passes, since the constraint is defined on the transform.

This is a bit of a pain but unfortunately it is a part of numpyro and because we use `numpyro.distributions` we cant avoid it.

Note: This does not catch invalid supports in the other direction, in this example this TruncatedNormal distribution can still sample values of 1000000000, which may mess up the sampler. This is wrong but not _invalid_ from the perspective of the config file. Invalid means it has no place in nature, while a huge number is ridiculous, it is a different kind of wrong. The user can always specify a upper bound on constraints to avoid this problem though. It just is not being enforced in the same way. 

CLOSES #54 