### PR TITLE
Update vaccination model in the seip

### DIFF
--- a/model_odes/seip_model.py
+++ b/model_odes/seip_model.py
@@ -132,7 +132,9 @@ def seip_ode(state, t, parameters):
     # input vaccination rate is per entire population, need to update to per compartments first
     vax_rates = p.VACCINATION_RATES(t)
     vax_totals = vax_rates * p.POPULATION[:, None]
-    vax_status_counts = jnp.sum(s, axis=(1, 3))
+    vax_status_counts = jnp.sum(
+        s, axis=(1, 3)
+    )  # Sum over immune hist and waning to get count per age and vax status
     updated_vax_rates = vax_totals / vax_status_counts
     updated_vax_rates = jnp.where(
         updated_vax_rates > 1.0,


### PR DESCRIPTION
- Convert input vaccination rate (which is per population) to per compartments
- Only disallows people in first waning compartment to receive vaccine when they already got 2 or more doses

resolves #80 