### PR TITLE
removing deprecated config variable names

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -462,15 +462,6 @@ PARAMETERS = [
         ],
     },
     {
-        "name": "STRAIN_SPECIFIC_R0",
-        "validate": [
-            partial(test_type, tested_type=np.ndarray),
-            test_non_empty,
-            partial(test_all_in_list, func=test_positive),
-        ],
-        "type": np.array,
-    },
-    {
         "name": "WANING_TIMES",
         "validate": [
             partial(test_type, tested_type=list),
@@ -550,7 +541,7 @@ PARAMETERS = [
         "validate": [
             partial(test_type, tested_type=np.ndarray),
             test_non_empty,
-            partial(test_all_in_list, func=test_positive),
+            partial(test_all_in_list, func=test_not_negative),
         ],
         "type": np.array,
     },

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -74,30 +74,10 @@ def test_output_shapes():
         static_params.INITIAL_STATE, 0, static_params.get_parameters()
     )
     expected_output_shapes = [
-        (
-            static_params.config.NUM_AGE_GROUPS,
-            2**static_params.config.NUM_STRAINS,
-            static_params.config.MAX_VAX_COUNT + 1,
-            static_params.config.NUM_WANING_COMPARTMENTS,
-        ),
-        (
-            static_params.config.NUM_AGE_GROUPS,
-            2**static_params.config.NUM_STRAINS,
-            static_params.config.MAX_VAX_COUNT + 1,
-            static_params.config.NUM_STRAINS,
-        ),
-        (
-            static_params.config.NUM_AGE_GROUPS,
-            2**static_params.config.NUM_STRAINS,
-            static_params.config.MAX_VAX_COUNT + 1,
-            static_params.config.NUM_STRAINS,
-        ),
-        (
-            static_params.config.NUM_AGE_GROUPS,
-            2**static_params.config.NUM_STRAINS,
-            static_params.config.MAX_VAX_COUNT + 1,
-            static_params.config.NUM_STRAINS,
-        ),
+        S_SHAPE,
+        EIC_SHAPE,
+        EIC_SHAPE,
+        EIC_SHAPE,
     ]
     for compartment, expected_shape in zip(
         first_derivatives, expected_output_shapes


### PR DESCRIPTION
removing STRAIN_SPECIFIC_R0 from config variables list since that is an old name, tiny change to test_runner for code reuse

I also set `STRAIN_R0s` validation test to be `test_not_negative` rather than `test_positive` because technically an R0 of 0 is mathematically valid and useful for testing. 