### PR TITLE
update viz app to give date and mention covid

### DIFF
--- a/visualizer_app.py
+++ b/visualizer_app.py
@@ -4,11 +4,12 @@ initialized with the config_base.py config file. This file is an active work in 
 get an understanding of the context that their mechanistic model is being run in.
 """
 
+import json
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sn
-import json
 from shiny import App, render, ui
 
 import utils


### PR DESCRIPTION
Hi guys,

As mentioned in #156 , I really like this viz tool for interrogating the assumptions around the initial state of the model but I do think it needed a more descriptive header.

This PR just grabs the date from the appropriate config file and adds that to header as well as mentioning covid (a nod towards future flu work...).

Closes #156 .