### PR TITLE
adding duel logging to utils for AB use

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import datetime
 import glob
 import json
 import os
+import sys
 from enum import IntEnum
 
 import epiweeks
@@ -2397,3 +2398,49 @@ class Parameters(object):
 
     def __init__(self, dict: dict):
         self.__dict__ = dict
+
+
+class dual_logger_out(object):
+    """
+    a class that splits stdout, flushing its contents to a file as well as to stdout
+    this is useful for Azure Batch to save logs but also see the output live on the node
+    """
+
+    def __init__(self, name, mode):
+        self.file = open(name, mode)
+        self.stdout = sys.stdout
+        sys.stdout = self
+
+    def close(self):
+        sys.stdout = self.stdout
+        self.file.close()
+
+    def write(self, data):
+        self.file.write(data)
+        self.stdout.write(data)
+
+    def flush(self):
+        self.file.flush()
+
+
+class dual_logger_err(object):
+    """
+    a class that splits stderror, flushing its contents to a file as well as to terminal if an error occurs
+    this is useful for Azure Batch to save logs but also see the output live on the node
+    """
+
+    def __init__(self, name, mode):
+        self.file = open(name, mode)
+        self.stderr = sys.stderr
+        sys.stderr = self
+
+    def close(self):
+        sys.stderr = self.stderr
+        self.file.close()
+
+    def write(self, data):
+        self.file.write(data)
+        self.stderr.write(data)
+
+    def flush(self):
+        self.file.flush()


### PR DESCRIPTION
This allows us to split `stdout` and `stderror` both to a file and to the normal `sys.stdout` and `sys.stderror` streams. This is useful for Azure batch because `stdout` and `stderror` are updated live on the node, but are also deleted once the pool decreases in size (almost immediately after job completion). With this method we can save the logs after the job completes, but still see the output as it happens.

Thanks @kokbent  for the code, I implemented it as is because I did not want to overengineer a solution using some Abstract Azure Runner class. This way these classes can still be used locally if needed.

CLOSES #150 
