### PR TITLE
create poisson rate safety along with longer test sampling

### DIFF
--- a/mechanistic_model/mechanistic_inferer.py
+++ b/mechanistic_model/mechanistic_inferer.py
@@ -113,6 +113,8 @@ class MechanisticInferer(AbstractParameters):
         )
         # axis = 0 because we take diff across time
         model_incidence = jnp.diff(model_incidence, axis=0)
+        poisson_rates = jnp.maximum(model_incidence, 1e-6)
+
         # save the final timestep of solution array for each compartment
         numpyro.deterministic(
             "final_timestep_s", solution.ys[self.config.COMPARTMENT_IDX.S][-1]
@@ -132,7 +134,7 @@ class MechanisticInferer(AbstractParameters):
 
         numpyro.sample(
             "incidence",
-            Dist.Poisson(model_incidence * ihr),
+            Dist.Poisson(poisson_rates * ihr),
             obs=obs_metrics,
         )
 

--- a/tests/test_inferer.py
+++ b/tests/test_inferer.py
@@ -47,6 +47,7 @@ ihr = [0.002, 0.004, 0.008, 0.06]
 model_incidence = jnp.sum(synthetic_solution.ys[3], axis=(2, 3, 4))
 model_incidence = jnp.diff(model_incidence, axis=0)
 synthetic_hosp_obs = np.asarray(model_incidence) * ihr
+synthetic_hosp_obs = jnp.rint(synthetic_hosp_obs).astype(int)
 
 inferer = MechanisticInferer(
     GLOBAL_CONFIG_PATH, INFERER_CONFIG_PATH, runner, fake_initial_state


### PR DESCRIPTION
A small PR to address #163 and #162 .

This implements non-negativity in the log-likelihood function for the predicted mean number of hosps in a standard way (element wise max). It also adjusts the test inference at `/tests/test_infer.py` to sample more and to have integer valued synthetic data generated from the model.

Downsides:
- The positive up-jitter `1e-6` is a bit of a magic number here.
- Visually, the inference is now capturing the chosen parameters that generated the synthetic data... but maybe this should be tested more rigorously?

Closes #163.

## Testing scope

Following discussion in #162  I'm amended the commit of this PR to only cover the change to the log-likelihood function and a round to integer operation in the synthetic data.