### PR TITLE
adding sero timelines for each timeline saved

### DIFF
--- a/experiment_setup.py
+++ b/experiment_setup.py
@@ -221,7 +221,6 @@ if __name__ == "__main__":
         columns=pops.columns,
     )
     pops = pd.concat([pops, usa_pop_row], ignore_index=True)
-    print(pops)
     args = parser.parse_args()
     exp = args.exp
     states = args.states


### PR DESCRIPTION
adding new default column to azure_visualizer_timelines that measures the sero-positive proportion by age bin over the course of the run. 

Also deleting an annoying print statement I accidentally kept in.