### PR TITLE
Adding stresstest function to `MechanisticInferer`

### DIFF
--- a/tests/test_inferer.py
+++ b/tests/test_inferer.py
@@ -80,6 +80,13 @@ def test_load_posterior_particle():
             ), "load_posterior_particle produced different timeline shapes than what was fit on"
 
 
+def test_stresstest_runs():
+    failed_params = inferer.stresstest(1000, tf=10)
+    assert (
+        len(failed_params) >= 0
+    ), "Params causing failure not returning as a list"
+
+
 def test_external_posteriors():
     load_across_chains = [
         (chain, 0) for chain in range(inferer.config.INFERENCE_NUM_CHAINS)


### PR DESCRIPTION
This PR adds a `stresstest` method to the `MechanisticInferer` class which:
- runs a `trace` on the `numpyro` model defined within a class instance to gather parameter names.
- Generates a `N` long list of parameters with cauchy random values.
- Passes these to `potential_energy`. NB: `potential_energy` expects parameters in the unconstrained domain, which is convenient here.
- Returns all parameters which cause:
  - model run failure.
  - `NaN` return value.
  - `Inf` return value.

I've added a unit test too which only covers whether it runs and returns a list.

### Caveats
I'm expecting this method to be inherited by any subtype of `MechanisticInferer` so that overloaded `loglikelihood` model methods should be covered by `stresstest`, but I'm not very strong at python so I might be misunderstanding inheritance here.

NB: For `stresstest` to work it requires `kwargs` to pass to the model via `get_trace`, which `kwargs` depends on the model (e.g. for the default model `tf = a_number` was sufficient).

Closes #197 

### Local pytest fail

I'm seeing this, but I can't seem to fix it on my local testing.

> FAILED tests/test_integration.py::test_output_matches_previous_version - AssertionError: a change was detected in the 0 compartment. This can be for a couple of valid reasons:

