### PR TITLE
adding ability to provide extra_timelines to azure_visualizer_csvs

### DIFF
--- a/mechanistic_model/abstract_azure_runner.py
+++ b/mechanistic_model/abstract_azure_runner.py
@@ -281,7 +281,7 @@ class AbstractAzureRunner(ABC):
         extra_timelines: pd.DataFrame = None,
     ) -> str:
         """saves history of inferer sampled values for use by the azure visualizer.
-        saves JSON file to `self.azure_output_dir/timeline_filename`.
+        saves CSV file to `self.azure_output_dir/timeline_filename`.
         Look at `shiny_visualizers/azure_visualizer.py` for logic on parsing and visualizing the chains.
         Will error if inferer.infer() has not been run previous to this call.
 


### PR DESCRIPTION
User can now supply an `extra_timelines` pandas dataframe, containing timeseries they would like saved alongside the normal suite saved by the `save_inference_posteriors()` method. 

This will most commonly be used to save observed data such as observed hospitalizations / obs var proportions / sero surveys. 

These can be displayed as scatter plots over the plots with the predicted values for these columns.