### PR TITLE
Fixing load posterior particle sampling behavior

### DIFF
--- a/mechanistic_model/mechanistic_inferer.py
+++ b/mechanistic_model/mechanistic_inferer.py
@@ -100,10 +100,7 @@ class MechanisticInferer(AbstractParameters):
         obs_metrics: Union[jax.Array, None] = None,
         tf: int = None,
         infer_mode=True,
-    ) -> dict[
-        str,
-        Union[Solution, jax.Array],
-    ]:
+    ) -> dict[str, Union[Solution, jax.Array],]:
         """
         Given some observed metrics, samples the likelihood of them occuring
         under a set of parameter distributions sampled by self.inference_algo.

--- a/tests/test_inferer.py
+++ b/tests/test_inferer.py
@@ -130,7 +130,7 @@ def test_random_sampling_across_chains_and_particles():
     for chain in range(inferer.config.INFERENCE_NUM_CHAINS):
         # get both particles across both inferers for this chain
         inferer1_chain_particle_0 = inferer1_posteriors[(chain, 0)]
-        inferer1_chain_particle_1 = inferer1_posteriors[(chain, 1)]
+        # inferer1_chain_particle_1 = inferer1_posteriors[(chain, 1)]
         inferer2_chain_particle_0 = inferer2_posteriors[(chain, 0)]
         inferer2_chain_particle_1 = inferer2_posteriors[(chain, 1)]
         # make sure that we are randomly sampling the dropped parameter


### PR DESCRIPTION
as mentioned in #213 the `load_posterior_particles` function was using the same seed to sample previously unobserved parameters across particles. This basically means that if you sampled a parameter not found within your posteriors, it would always be the same value across different chains and particles.

This was fixed by adding some salting between the chain and particle values to the random seed, a test was also created to ensure the bug would not return.

CLOSES #213 