### PR TITLE
mypy static type checking

### DIFF
--- a/mechanistic_model/__init__.py
+++ b/mechanistic_model/__init__.py
@@ -1,7 +1,24 @@
 # needs to exist to define a module
 import jax
 
+"""
+SEIC Compartments defines a tuple of the four major compartments used in the model
+S: Susceptible, E: exposed, I: Infectious, C: cumulative (book keeping)
+the dimension definitions of each of these compartments is
+defined by the following Enums within the global configuration file
+S: S_AXIS_IDX
+E/I/C: I_AXIS_IDX
+The exact sizes of each of these dimensions also depend on the implementation and config file
+"""
 SEIC_Compartments = tuple[
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+]
+# a timeseries is a tuple of compartment sizes where the leading dimension is time
+# so SEIC_Timeseries has shape (tf, SEIC_Compartments.shape) for some number of timesteps tf
+SEIC_Timeseries = tuple[
     jax.Array,
     jax.Array,
     jax.Array,

--- a/mechanistic_model/utils.py
+++ b/mechanistic_model/utils.py
@@ -972,8 +972,8 @@ def drop_sample_chains(samples: dict, dropped_chain_vals: list):
 
 
 def flatten_list_parameters(
-    samples: dict[str : np.ndarray],
-) -> dict[str : np.ndarray]:
+    samples: dict[str, np.ndarray],
+) -> dict[str, np.ndarray]:
     """
     given a dictionary of parameter names and samples, identifies any parameters that are
     placed under a single name, but actually multiple independent draws from the same distribution.


### PR DESCRIPTION
mypy is not a requirement within pre-commit because I believe it enforces too much overhead which may get in the way of a response. however this does not mean we should not attempt to enforce it during infrastructure rebuilding.

From now I will be making a conscious effort to mypy check new files, starting with the major files within `mechanistic_model/`

No changes to code behavior (other than runner now takes only `int` or `datetime.date` and no `datetime.datetime` parameter types). 
This is part of #224 but is not closing it.