### PR TITLE
bugfix azure download utilities unexpected behavior on sequential calls

### DIFF
--- a/mechanistic_azure/azure_utilities.py
+++ b/mechanistic_azure/azure_utilities.py
@@ -413,10 +413,10 @@ def download_directory_from_azure(
                 cfa_azure.helpers.download_directory(
                     azure_client.out_cont_client, azure_dir, dest
                 )
-                written_dirs.append(dest_path)
             except ValueError as e:
                 raise ValueError(
                     "failed to download %s, but not before successfully downloading %s"
                     % (dest_path, str(written_dirs))
                 ) from e
+        written_dirs.append(dest_path)
     return written_dirs


### PR DESCRIPTION
if a user already has files in the `dest_path` the download_directory_from_azure will not return the paths to those files unless overwrite=True.

This was caught by an error in the shiny_visualizer which uses this code to download job output, it will not redownload the jobs if they are already loaded in the local machine, thus running multiple separate visualizations of the shiny visualizer would break it.

bug was created in #239 so it was caught quickly.