### PR TITLE
.gitignore exception for template configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ testing.py
 !pyproject.toml
 !azure/docker_template_configs/*.json
 !exp/example_azure_experiment/example_template_configs/*.json
+!exp/*/template_configs/*.json
 
 #####
 # Python


### PR DESCRIPTION
adding an exception such that new branches will automatically upload their experiment template configs to git