### PR TITLE
Docker build adds all of src within. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,3 @@ COPY ./src/ /app/src
 # turn off interaction since we cant type `yes` on the prompts in docker build
 RUN poetry install --no-interaction --no-ansi
 # we will upload the experiment itself into the cloud and refer to from /input
-# COPY ./mechanistic_azure/abstract_azure_runner.py /app/mechanistic_azure/abstract_azure_runner.py
-# COPY ./mechanistic_azure/azure_utilities.py /app/mechanistic_azure/azure_utilities.py


### PR DESCRIPTION
we have moved `mechanistic_azure` into `src`, which was being referred to as a separate folder in the dockerfile, fixing that.