### PR TITLE
Add notice to readme warning of active development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # CFA Scenarios Model
 
-> [!IMPORTANT]
-> This repository is under active development and will be substantially refactored in the near future.
-> Please look around, but we advise against working with this code until it has stabilized.
-
 [Overview](#overview) |
 [Model Structure](#model-structure) |
 [Quick Start](#quick-start) |
@@ -12,6 +8,10 @@
 [Fine Text and Disclaimers](#general-disclaimer)
 
 ## Overview
+
+> [!IMPORTANT]
+> This repository is under active development and will be substantially refactored in the near future.
+> Please look around, but we advise against working with this code until it has stabilized.
 
 This repository is for the design and implementation of a Scenarios forecasting model, built by the Scenarios team within CFA-Predict.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # CFA Scenarios Model
+
+> [!IMPORTANT]
+> This repository is under active development and will be substantially refactored in the near future.
+> Please look around, but we advise against working with this code until it has stabilized.
+
 [Overview](#overview) |
 [Model Structure](#model-structure) |
 [Quick Start](#quick-start) |
 [Data Sources](#data-sources) |
 [Project Admins](#project-admins) |
 [Fine Text and Disclaimers](#general-disclaimer)
+
 ## Overview
 
 This repository is for the design and implementation of a Scenarios forecasting model, built by the Scenarios team within CFA-Predict.


### PR DESCRIPTION
I added an [!IMPORTANT notice](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) to the readme indicating that this code is under active development.

Wasn't sure exactly where to put it, but any higher looked visually strange.

Perhaps also worth editing repo description.

`!CAUTION` and `!WARNING` seemed too strong (and they also seem semantically backwards in the GitHub notice implementation).