### PR TITLE
Vis utils

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -107,6 +107,24 @@ typing-extensions = {version = ">=4", markers = "python_version < \"3.11\""}
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
+name = "asttokens"
+version = "2.4.1"
+description = "Annotate AST trees with source code positions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24"},
+    {file = "asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0"},
+]
+
+[package.dependencies]
+six = ">=1.12.0"
+
+[package.extras]
+astroid = ["astroid (>=1,<2)", "astroid (>=2,<4)"]
+test = ["astroid (>=1,<2)", "astroid (>=2,<4)", "pytest"]
+
+[[package]]
 name = "azure-batch"
 version = "14.0.0"
 description = "Microsoft Azure Batch Client Library for Python"
@@ -642,6 +660,23 @@ files = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.2"
+description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3"},
+    {file = "comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e"},
+]
+
+[package.dependencies]
+traitlets = ">=4"
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
 name = "cons"
 version = "0.4.6"
 description = "An implementation of Lisp/Scheme-like cons in Python."
@@ -1043,6 +1078,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "executing"
+version = "2.1.0"
+description = "Get the currently executing AST node of a frame, and other information"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf"},
+    {file = "executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab"},
+]
+
+[package.extras]
+tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipython", "littleutils", "pytest", "rich"]
+
+[[package]]
 name = "fastprogress"
 version = "1.0.3"
 description = "A nested progress with plotting options for fastai"
@@ -1417,6 +1466,63 @@ files = [
 ]
 
 [[package]]
+name = "ipython"
+version = "8.18.0"
+description = "IPython: Productive Interactive Computing"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "ipython-8.18.0-py3-none-any.whl", hash = "sha256:d538a7a98ad9b7e018926447a5f35856113a85d08fd68a165d7871ab5175f6e0"},
+    {file = "ipython-8.18.0.tar.gz", hash = "sha256:4feb61210160f75e229ce932dbf8b719bff37af123c0b985fd038b14233daa16"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+decorator = "*"
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+jedi = ">=0.16"
+matplotlib-inline = "*"
+pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
+prompt-toolkit = ">=3.0.30,<3.0.37 || >3.0.37,<3.1.0"
+pygments = ">=2.4.0"
+stack-data = "*"
+traitlets = ">=5"
+
+[package.extras]
+all = ["black", "curio", "docrepr", "exceptiongroup", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
+black = ["black"]
+doc = ["docrepr", "exceptiongroup", "ipykernel", "matplotlib", "pickleshare", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio (<0.22)", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "typing-extensions"]
+kernel = ["ipykernel"]
+nbconvert = ["nbconvert"]
+nbformat = ["nbformat"]
+notebook = ["ipywidgets", "notebook"]
+parallel = ["ipyparallel"]
+qtconsole = ["qtconsole"]
+test = ["pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath"]
+test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.22)", "pandas", "pickleshare", "pytest (<7.1)", "pytest-asyncio (<0.22)", "testpath", "trio"]
+
+[[package]]
+name = "ipywidgets"
+version = "8.1.5"
+description = "Jupyter interactive widgets"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ipywidgets-8.1.5-py3-none-any.whl", hash = "sha256:3290f526f87ae6e77655555baba4f36681c555b8bdbbff430b70e52c34c86245"},
+    {file = "ipywidgets-8.1.5.tar.gz", hash = "sha256:870e43b1a35656a80c18c9503bbf2d16802db1cb487eec6fab27d683381dde17"},
+]
+
+[package.dependencies]
+comm = ">=0.1.3"
+ipython = ">=6.1.0"
+jupyterlab-widgets = ">=3.0.12,<3.1.0"
+traitlets = ">=4.3.1"
+widgetsnbextension = ">=4.0.12,<4.1.0"
+
+[package.extras]
+test = ["ipykernel", "jsonschema", "pytest (>=3.6.0)", "pytest-cov", "pytz"]
+
+[[package]]
 name = "isodate"
 version = "0.6.1"
 description = "An ISO 8601 date/time/duration parser and formatter"
@@ -1536,6 +1642,56 @@ files = [
 
 [package.dependencies]
 typeguard = "2.13.3"
+
+[[package]]
+name = "jedi"
+version = "0.19.1"
+description = "An autocompletion tool for Python that can be used for text editors."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"},
+    {file = "jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd"},
+]
+
+[package.dependencies]
+parso = ">=0.8.3,<0.9.0"
+
+[package.extras]
+docs = ["Jinja2 (==2.11.3)", "MarkupSafe (==1.1.1)", "Pygments (==2.8.1)", "alabaster (==0.7.12)", "babel (==2.9.1)", "chardet (==4.0.0)", "commonmark (==0.8.1)", "docutils (==0.17.1)", "future (==0.18.2)", "idna (==2.10)", "imagesize (==1.2.0)", "mock (==1.0.1)", "packaging (==20.9)", "pyparsing (==2.4.7)", "pytz (==2021.1)", "readthedocs-sphinx-ext (==2.1.4)", "recommonmark (==0.5.0)", "requests (==2.25.1)", "six (==1.15.0)", "snowballstemmer (==2.1.0)", "sphinx (==1.8.5)", "sphinx-rtd-theme (==0.4.3)", "sphinxcontrib-serializinghtml (==1.1.4)", "sphinxcontrib-websupport (==1.2.4)", "urllib3 (==1.26.4)"]
+qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
+testing = ["Django", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
+
+[[package]]
+name = "jupyter-core"
+version = "5.7.2"
+description = "Jupyter core package. A base package on which Jupyter projects rely."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409"},
+    {file = "jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9"},
+]
+
+[package.dependencies]
+platformdirs = ">=2.5"
+pywin32 = {version = ">=300", markers = "sys_platform == \"win32\" and platform_python_implementation != \"PyPy\""}
+traitlets = ">=5.3"
+
+[package.extras]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx-autodoc-typehints", "sphinxcontrib-github-alt", "sphinxcontrib-spelling", "traitlets"]
+test = ["ipykernel", "pre-commit", "pytest (<8)", "pytest-cov", "pytest-timeout"]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.13"
+description = "Jupyter interactive widgets for JupyterLab"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jupyterlab_widgets-3.0.13-py3-none-any.whl", hash = "sha256:e3cda2c233ce144192f1e29914ad522b2f4c40e77214b0cc97377ca3d323db54"},
+    {file = "jupyterlab_widgets-3.0.13.tar.gz", hash = "sha256:a2966d385328c1942b683a8cd96b89b8dd82c8b8f81dda902bb2bc06d46f5bed"},
+]
 
 [[package]]
 name = "kiwisolver"
@@ -1776,6 +1932,20 @@ python-dateutil = ">=2.7"
 
 [package.extras]
 dev = ["meson-python (>=0.13.1)", "numpy (>=1.25)", "pybind11 (>=2.6)", "setuptools (>=64)", "setuptools_scm (>=7)"]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.7"
+description = "Inline Matplotlib backend for Jupyter"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca"},
+    {file = "matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90"},
+]
+
+[package.dependencies]
+traitlets = "*"
 
 [[package]]
 name = "mdit-py-plugins"
@@ -2411,6 +2581,21 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "parso"
+version = "0.8.4"
+description = "A Python Parser"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18"},
+    {file = "parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d"},
+]
+
+[package.extras]
+qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
+testing = ["docopt", "pytest"]
+
+[[package]]
 name = "pathlib"
 version = "1.0.1"
 description = "Object-oriented filesystem paths"
@@ -2420,6 +2605,20 @@ files = [
     {file = "pathlib-1.0.1-py3-none-any.whl", hash = "sha256:f35f95ab8b0f59e6d354090350b44a80a80635d22efdedfa84c7ad1cf0a74147"},
     {file = "pathlib-1.0.1.tar.gz", hash = "sha256:6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f"},
 ]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+description = "Pexpect allows easy control of interactive console applications."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
+    {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
+]
+
+[package.dependencies]
+ptyprocess = ">=0.5"
 
 [[package]]
 name = "pillow"
@@ -2546,6 +2745,21 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-
 type = ["mypy (>=1.8)"]
 
 [[package]]
+name = "plotly"
+version = "5.24.1"
+description = "An open-source, interactive data visualization library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089"},
+    {file = "plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae"},
+]
+
+[package.dependencies]
+packaging = "*"
+tenacity = ">=6.2.0"
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
@@ -2630,6 +2844,31 @@ files = [
     {file = "protobuf-5.28.0-py3-none-any.whl", hash = "sha256:510ed78cd0980f6d3218099e874714cdf0d8a95582e7b059b06cabad855ed0a0"},
     {file = "protobuf-5.28.0.tar.gz", hash = "sha256:dde74af0fa774fa98892209992295adbfb91da3fa98c8f67a88afe8f5a349add"},
 ]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+description = "Safely evaluate AST nodes without side effects"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
+    {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
+]
+
+[package.extras]
+tests = ["pytest"]
 
 [[package]]
 name = "pyarrow"
@@ -3173,6 +3412,27 @@ test = ["astropy", "bokeh", "coverage", "duckdb", "faicons", "folium", "geodatas
 theme = ["libsass (>=0.23.0)"]
 
 [[package]]
+name = "shinywidgets"
+version = "0.3.3"
+description = "Render ipywidgets in Shiny applications"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "shinywidgets-0.3.3-py3-none-any.whl", hash = "sha256:e0290a6985e41eafdfbd487d6a86449d6e8692ac0d99dee307f5ad0aa1fd5a93"},
+    {file = "shinywidgets-0.3.3.tar.gz", hash = "sha256:9827da55d3f57dfa0b8c5158547dde048d52a835bca1a8720655fcb0990ac008"},
+]
+
+[package.dependencies]
+ipywidgets = ">=7.6.5"
+jupyter-core = "*"
+python-dateutil = ">=2.8.2"
+shiny = ">=0.6.1.9005"
+
+[package.extras]
+dev = ["black (>=23.1.0)", "flake8 (==3.9.2)", "flake8 (>=6.0.0)", "isort (>=5.11.2)", "pyright (>=1.1.284)", "wheel"]
+test = ["pytest (>=6.2.4)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3206,6 +3466,25 @@ files = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+description = "Extract data from python stack frames and tracebacks for informative displays"
+optional = false
+python-versions = "*"
+files = [
+    {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
+    {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
+]
+
+[package.dependencies]
+asttokens = ">=2.1.0"
+executing = ">=1.2.0"
+pure-eval = "*"
+
+[package.extras]
+tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
 name = "starlette"
 version = "0.38.2"
 description = "The little ASGI library that shines."
@@ -3221,6 +3500,21 @@ anyio = ">=3.4.0,<5"
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+
+[[package]]
+name = "tenacity"
+version = "9.0.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
+    {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
 
 [[package]]
 name = "tensorflow-probability"
@@ -3334,6 +3628,21 @@ dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+description = "Traitlets Python configuration system"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
+    {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
+]
+
+[package.extras]
+docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
+test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
 name = "typeguard"
@@ -3634,6 +3943,17 @@ files = [
 ]
 
 [[package]]
+name = "widgetsnbextension"
+version = "4.0.13"
+description = "Jupyter interactive widgets for Jupyter Notebook"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "widgetsnbextension-4.0.13-py3-none-any.whl", hash = "sha256:74b2692e8500525cc38c2b877236ba51d34541e6385eeed5aec15a70f88a6c71"},
+    {file = "widgetsnbextension-4.0.13.tar.gz", hash = "sha256:ffcb67bc9febd10234a362795f643927f4e0c05d9342c727b65d2384f8feacb6"},
+]
+
+[[package]]
 name = "xarray"
 version = "2024.7.0"
 description = "N-D labeled arrays and datasets in Python"
@@ -3701,4 +4021,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "fcc0f82d49fec7ce5eec9213904a147e84e775c9616532e007b8787f581d81d1"
+content-hash = "196cf9a64445e1a7e6843c95769808e940b3fc3994e5fac53610c3ad5530b73f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ mypy = "^1.10.0"
 requests = "^2.32.3"
 docker = "^7.1.0"
 bayeux-ml = "^0.1.14"
+plotly = "^5.24.1"
+shinywidgets = "^0.3.3"
 
 
 [build-system]

--- a/src/mechanistic_azure/abstract_azure_runner.py
+++ b/src/mechanistic_azure/abstract_azure_runner.py
@@ -394,7 +394,7 @@ class AbstractAzureRunner(ABC):
         """
         fig = vis_utils.plot_mcmc_chains(samples, **plot_kwargs)
         save_path = os.path.join(self.azure_output_dir, save_filename)
-        fig.savefig(save_path)
+        fig.savefig(save_path, bbox_inches="tight")
 
     def save_correlation_pairs_plot(
         self,
@@ -424,7 +424,7 @@ class AbstractAzureRunner(ABC):
             samples, **plot_kwargs
         )
         save_path = os.path.join(self.azure_output_dir, save_filename)
-        fig.savefig(save_path)
+        fig.savefig(save_path, bbox_inches="tight")
 
     def save_inference_posteriors(
         self,

--- a/src/resp_ode/__init__.py
+++ b/src/resp_ode/__init__.py
@@ -26,7 +26,7 @@ SEIC_Timeseries = tuple[
     jax.Array,
 ]
 
-from . import utils
+from . import utils, vis_utils
 
 # keep imports relative to avoid circular importing
 from .abstract_initializer import AbstractInitializer
@@ -49,4 +49,5 @@ __all__ = [
     StaticValueParameters,
     utils,
     Config,
+    vis_utils,
 ]

--- a/src/resp_ode/vis_utils.py
+++ b/src/resp_ode/vis_utils.py
@@ -366,7 +366,6 @@ def plot_checkpoint_inference_correlation_pairs(
             vars=columns,
             diag_sharey=False,
             layout_pad=0.01,
-            figsize=(3 * num_cols, 3 * num_cols),
         )
     g.map_upper(reg_coef)
     g = g.map_lower(
@@ -385,8 +384,8 @@ def plot_checkpoint_inference_correlation_pairs(
         ax.set_ylabel(ylabel, size=label_size, rotation=0, labelpad=15.0)
         ax.label_outer(remove_inner_ticks=True)
     # Adjust layout to make sure everything fits
-    # px = 1 / plt.rcParams["figure.dpi"]
-    # g.figure.set_size_inches((1600 * px, 1600 * px))
+    px = 1 / plt.rcParams["figure.dpi"]
+    g.figure.set_size_inches((2000 * px, 2000 * px))
     # g.figure.tight_layout(pad=0.01, h_pad=0.01, w_pad=0.01)
     return g.figure
 

--- a/src/resp_ode/vis_utils.py
+++ b/src/resp_ode/vis_utils.py
@@ -157,7 +157,7 @@ def plot_model_overview_subplot_matplotlib(
             sharex=True,
             sharey="row",
             squeeze=False,
-            figsize=(15, 15),
+            figsize=(6 * num_states, 3 * num_unique_plots_in_timelines),
         )
     # melt this df down to have an ID column "column" and a value column "val"
     id_vars = ["date", "state", "chain_particle"]
@@ -242,7 +242,8 @@ def plot_model_overview_subplot_matplotlib(
                     )
     # add column titles on the top of each col for the states
     for ax, state in zip(ax[0], timeseries_df["state"].unique()):
-        ax.set_title(state)
+        plot_title = ax.get_title()
+        ax.set_title(plot_title + "\n" + state)
     fig.tight_layout()
 
     return fig
@@ -365,6 +366,7 @@ def plot_checkpoint_inference_correlation_pairs(
             vars=columns,
             diag_sharey=False,
             layout_pad=0.01,
+            figsize=(3 * num_cols, 3 * num_cols),
         )
     g.map_upper(reg_coef)
     g = g.map_lower(
@@ -383,8 +385,8 @@ def plot_checkpoint_inference_correlation_pairs(
         ax.set_ylabel(ylabel, size=label_size, rotation=0, labelpad=15.0)
         ax.label_outer(remove_inner_ticks=True)
     # Adjust layout to make sure everything fits
-    px = 1 / plt.rcParams["figure.dpi"]
-    g.figure.set_size_inches((1600 * px, 1600 * px))
+    # px = 1 / plt.rcParams["figure.dpi"]
+    # g.figure.set_size_inches((1600 * px, 1600 * px))
     # g.figure.tight_layout(pad=0.01, h_pad=0.01, w_pad=0.01)
     return g.figure
 

--- a/src/resp_ode/vis_utils.py
+++ b/src/resp_ode/vis_utils.py
@@ -1,0 +1,197 @@
+"""A series of utility functions for generating visualizations for the model"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+
+def _cleanup_and_normalize_timelines(
+    all_state_timelines,
+    plot_types,
+    plot_normalizations,
+    states,
+    state_pop_sizes,
+):
+    # Select columns with 'float64' dtype
+    float_cols = list(all_state_timelines.select_dtypes(include="float64"))
+    # round down near-zero values to zero to make plots cleaner
+    all_state_timelines[float_cols] = all_state_timelines[float_cols].mask(
+        np.isclose(all_state_timelines[float_cols], 0, atol=1e-4), 0
+    )
+    for plot_type, plot_normalization in zip(plot_types, plot_normalizations):
+        for state_name, state_pop in zip(states, state_pop_sizes):
+            # if normalization is set to 1, we dont normalize at all.
+            normalization_factor = (
+                plot_normalization / state_pop
+                if plot_normalization > 1
+                else 1.0
+            )
+            # select all columns from that column type
+            cols = [
+                col for col in all_state_timelines.columns if plot_type in col
+            ]
+            # update that states columns by the normalization factor chosen for that column
+            all_state_timelines.loc[
+                all_state_timelines["state"] == state_name,
+                cols,
+            ] *= normalization_factor
+    return all_state_timelines
+
+
+def generate_model_overview_subplot_matplotlib(
+    timeseries_df: pd.DataFrame,
+    pop_sizes: list[int],
+    plot_types=np.array(
+        [
+            "seasonality_coef",
+            "vaccination_",
+            "_external_introductions",
+            "_strain_proportion",
+            "_average_immunity",
+            "total_infection_incidence",  # TODO MAKE AGE SPECIFIC
+            "pred_hosp_",
+        ]
+    ),
+    plot_titles=np.array(
+        [
+            "Seasonality Coefficient",
+            "Vaccination Rate By Age",
+            "External Introductions by Strain (per 100k)",
+            "Strain Proportion of New Infections",
+            "Average Population Immunity Against Strains",
+            "Total Infection Incidence (per 100k)",
+            "Predicted Hospitalizations (per 100k)",
+        ]
+    ),
+    plot_normalizations=np.array([1, 1, 100000, 1, 1, 100000, 100000]),
+):
+    """Given a dataframe resembling the azure_visualizer_timeline csv, if it exists, returns an overview figure.
+    the figure will contain 1 column per state in `timeseries_df["states"]` if the column exists. The
+    figure will contain one row per
+
+    Parameters
+    ----------
+    timeseries_df : _type_
+        _description_
+    pop_sizes : _type_
+        _description_
+    plot_types : _type_, optional
+        _description_, by default [ "seasonality_coef", "vaccination_", "_external_introductions", "_strain_proportion", "_average_immunity", "total_infection_incidence", "pred_hosp_", ]
+    plot_titles : _type_, optional
+        _description_, by default [ "Seasonality Coefficient", "Vaccination Rate By Age", "External Introductions by Strain (per 100k)", "Strain Proportion of New Infections", "Average Population Immunity Against Strains", "Total Infection Incidence (per 100k)", "Predicted Hospitalizations (per 100k)", ]
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
+    if "states" not in timeseries_df.columns:
+        timeseries_df["states"] = "state"
+    num_states = len(timeseries_df["states"].unique())
+    # we are counting the number of plot_types that are within timelines.columns
+    # this way we dont try to plot something that timelines does not have
+    plots_in_timelines = [
+        any([plot_type in col for col in timeseries_df.columns])
+        for plot_type in plot_types
+    ]
+    num_unique_plots_in_timelines = sum(plots_in_timelines)
+    # select only the plots we actually find within `timelines`
+    plot_types = plot_types[plots_in_timelines].tolist()
+    plot_titles = plot_titles[plots_in_timelines].tolist()
+    plot_normalizations = plot_normalizations[plots_in_timelines].tolist()
+    # normalize our dataframe by the given y axis normalization schemes
+    timeseries_df = _cleanup_and_normalize_timelines(
+        timeseries_df,
+        plot_types,
+        plot_normalizations,
+        pop_sizes,
+    )
+    plt.style.use("seaborn-v0_8-colorblind")
+    fig, ax = plt.subplots(
+        nrows=num_unique_plots_in_timelines,
+        ncols=num_states,
+        sharex=True,
+        sharey="row",
+        squeeze=False,
+        figsize=(15, 15),
+    )
+    # melt the df down so that each column is identified in one col rather than
+    # across all cols, this makes filtering more efficient and works with seaborn style
+    id_vars = ["date", "state", "chain_particle"]
+    rest = [x for x in timeseries_df.columns if x not in id_vars]
+    timelines_melt = pd.melt(
+        timeseries_df,
+        id_vars=["date", "state", "chain_particle"],
+        value_vars=rest,
+        var_name="column",
+        value_name="val",
+    )
+    # convert to datetime if not already
+    timelines_melt["date"] = pd.to_datetime(timelines_melt["date"])
+
+    # go through each plot type, look for matching columns within `timelines` and plot
+    # that plot_type for each chain_particle pair. plotly rows/cols are index at 1 not 0
+    for state_num, state in enumerate(timeseries_df["state"].unique()):
+        state_df = timelines_melt[timelines_melt["state"] == state]
+        print("Plotting State : " + state)
+        for plot_num, (plot_title, plot_type) in enumerate(
+            zip(plot_titles, plot_types)
+        ):
+            plot_ax = ax[plot_num][state_num]
+            # for example "vaccination_" in "vaccination_0_17" is true
+            # so we include this column in the plot under that plot_type
+            columns_to_plot = [
+                col for col in timelines_melt.columns if plot_type in col
+            ]
+            df = state_df[[plot_type in x for x in state_df["column"]]]
+            if len(columns_to_plot) > 1:
+                df.loc[:, "column"] = df.loc[:, "column"].apply(
+                    lambda x: x.replace(plot_type, "")
+                )
+            unique_columns = df["column"].unique()
+            # plot all chain_particles as thin transparent lines
+            sns.lineplot(
+                df,
+                x="date",
+                y="val",
+                hue="column",
+                units="chain_particle",
+                ax=plot_ax,
+                estimator=None,
+                alpha=0.3,
+                lw=0.25,
+                legend=False,
+                hue_order=unique_columns,
+            )
+            # plot a median line of all particles with high opacity
+            medians = df.groupby(by=["date", "column"])["val"].median()
+            medians = medians.reset_index()
+            sns.lineplot(
+                medians,
+                x="date",
+                y="val",
+                hue="column",
+                ax=plot_ax,
+                estimator=None,
+                alpha=1.0,
+                lw=2,
+                legend="auto",
+                hue_order=unique_columns,
+            )
+            # remove y labels
+            plot_ax.set_ylabel("")
+            plot_ax.set_title(plot_title)
+            # make all legends except those on far right invisible
+            plot_ax.get_legend().set_visible(False)
+            # create legend for the right most plot only
+            if state_num == num_states - 1:
+                for lh in plot_ax.get_legend().legend_handles:
+                    lh.set_alpha(1)
+                plot_ax.legend(bbox_to_anchor=(1.0, 0.5), loc="center left")
+    # add column titles on the top of each col for the states
+    for ax, state in zip(ax[0], timeseries_df["state"].unique()):
+        ax.set_title(state)
+    fig.tight_layout()
+
+    return fig


### PR DESCRIPTION
this PR adds the following functionality

1. Implements default saving of visualizations along with all calls to `abstract_azure_runner.save_inference_posteriors()` via the `save_mcmc_chains_plot` and `save_correlation_pairs_plot` functions
2. Adds the `vis_utils.py` file to `src/` that declares some useful utils functions for generating views of the model outputs (both the `azure_visualizer_timelines.csv` and the `checkpoint.json` files)
3. adds plotly and shinywidgets back into our version control since we are still using shiny to a limited extent

The idea behind these changes is to further automate the visualization pipeline so users can more easily see the results of their fits and/or projections.

This has the added benefit of opening the door to faster load times in the `shiny_visualizers/` apps as they can now load static images right away (especially useful for large plots like the correlation pairs plot.

CLOSES #276