### PR TITLE
locking cfa_azure version, adding state suffix to task ids

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -369,7 +369,7 @@ files = [
 
 [[package]]
 name = "cfa-azure"
-version = "0.3.7"
+version = "1.0.8"
 description = "module for use with Azure and Azure Batch"
 optional = false
 python-versions = "^3.8"
@@ -383,6 +383,7 @@ azure-identity = "1.16.1"
 azure-keyvault = "4.2.0"
 azure-mgmt-batch = "17.1.0"
 azure-storage-blob = "12.17.0"
+cryptography = "43.0.1"
 docker = "*"
 pandas = "*"
 pathlib = "*"
@@ -393,7 +394,7 @@ toml = "0.10.2"
 type = "git"
 url = "https://github.com/CDCgov/cfa_azure.git"
 reference = "HEAD"
-resolved_reference = "fede4c8a36036007516ebc82188733f389e8e849"
+resolved_reference = "5443bde21b3eeb99d6e5447ae6cb270dd1efdd91"
 
 [[package]]
 name = "cffi"
@@ -3714,4 +3715,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "fcc0f82d49fec7ce5eec9213904a147e84e775c9616532e007b8787f581d81d1"
+content-hash = "ed91b1492ebe61f4e5ba0c87c97bcd6404e4f8bbd9255383055a97991f2f4ae5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ pandas = ">=2.0.3"
 seaborn = ">=0.13.2"
 shiny = ">=0.6.0"
 pytest = ">=7.4.0"
-cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git"}
+cfa-azure = {git = "https://github.com/CDCgov/cfa_azure.git", rev="5443bde"}
 pip = "^24.0"
 epiweeks = "^2.3.0"
 pre-commit = "^3.7.1"

--- a/src/mechanistic_azure/azure_utilities.py
+++ b/src/mechanistic_azure/azure_utilities.py
@@ -272,6 +272,7 @@ class AzureExperimentLauncher:
                     docker_cmd="python %s -s %s -j %s"
                     % (self.runner_path_docker, statedir, self.job_id),
                     depends_on=depend_on_task_ids,
+                    name_suffix=statedir,
                 )
                 # append this list onto our running list of tasks
                 task_ids += task_id


### PR DESCRIPTION
upgrading and locking cfa_azure version to commit hash: 5443bde or version 1.0.8. This upgrade adds the ability for us to specify suffix onto each task launched. I went ahead and added the state name as the default suffix to aid in interpretability when reading task lists in batch explorer.

This upgrade also changes some keys in the configuration toml, please reach out to me if you are getting weird errors when trying to launch your jobs and I can pass you the file in a safe way (it is not tracked on git for obvious reasons)