### PR TITLE
adding readme badges and pyproject author

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 ![CI](https://github.com/CDCgov/cfa_azure/workflows/Python%20Unit%20Tests%20with%20Coverage/badge.svg?style=plastic&link=https://github.com/CDCgov/cfa_azure/actions/workflows/pre-commit.yaml&link=https://github.com/CDCgov/cfa_azure/actions/workflows/ci.yaml)
 ![GitHub License](https://img.shields.io/github/license/cdcgov/dynode?style=plastic&link=https://github.com/CDCgov/dynode/blob/master/LICENSE)
 ![Python](https://img.shields.io/badge/python-3670A0?logo=python&logoColor=ffdd54&style=plastic)
-![Azure](https://img.shields.io/badge/Microsoft-Azure-blue?logo=microsoftazure&logoColor=white&style=plastic)
 
 [Overview](#overview) |
 [Model Structure](#model-structure) |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# CFA Scenarios Model
+# DynODE : A Dynamic Ordinary Differential Package for Respiratory Disease Modeling
+
+![Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FCDCgov%2FDynODE%2Frefs%2Fheads%2Fmain%2Fpyproject.toml&query=%24.tool.poetry.version&style=plastic&label=version&color=lightgray)
+![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&style=plastic&link=https://raw.githubusercontent.com/CDCgov/cfa_azure/refs/heads/master/.pre-commit-config.yaml)
+![pre-commit](https://github.com/CDCgov/dynode/workflows/pre-commit/badge.svg?style=plastic&link=https://github.com/CDCgov/dynode/actions/workflows/pre-commit.yaml)
+![CI](https://github.com/CDCgov/cfa_azure/workflows/Python%20Unit%20Tests%20with%20Coverage/badge.svg?style=plastic&link=https://github.com/CDCgov/cfa_azure/actions/workflows/pre-commit.yaml&link=https://github.com/CDCgov/cfa_azure/actions/workflows/ci.yaml)
+![GitHub License](https://img.shields.io/github/license/cdcgov/dynode?style=plastic&link=https://github.com/CDCgov/dynode/blob/master/LICENSE)
+![Python](https://img.shields.io/badge/python-3670A0?logo=python&logoColor=ffdd54&style=plastic)
+![Azure](https://img.shields.io/badge/Microsoft-Azure-blue?logo=microsoftazure&logoColor=white&style=plastic)
 
 [Overview](#overview) |
 [Model Structure](#model-structure) |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # DynODE : A Dynamic Ordinary Differential Package for Respiratory Disease Modeling
 
 ![Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FCDCgov%2FDynODE%2Frefs%2Fheads%2Fmain%2Fpyproject.toml&query=%24.tool.poetry.version&style=plastic&label=version&color=lightgray)
-![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&style=plastic&link=https://raw.githubusercontent.com/CDCgov/cfa_azure/refs/heads/master/.pre-commit-config.yaml)
 ![pre-commit](https://github.com/CDCgov/dynode/workflows/pre-commit/badge.svg?style=plastic&link=https://github.com/CDCgov/dynode/actions/workflows/pre-commit.yaml)
 ![CI](https://github.com/CDCgov/cfa_azure/workflows/Python%20Unit%20Tests%20with%20Coverage/badge.svg?style=plastic&link=https://github.com/CDCgov/cfa_azure/actions/workflows/pre-commit.yaml&link=https://github.com/CDCgov/cfa_azure/actions/workflows/ci.yaml)
 ![GitHub License](https://img.shields.io/github/license/cdcgov/dynode?style=plastic&link=https://github.com/CDCgov/dynode/blob/master/LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dynode"
 version = "0.1.0"
 description = "CDC CFA Predict Scenarios model development"
-authors = ["Your Name <you@example.com>"]
+authors = ["CDC/CFA/Predict/Scenarios"]
 license = "Apache License, Version 2.0, January 2004"
 readme = "README.md"
 package-mode = true


### PR DESCRIPTION
a small commit meant to work on #314 but not closing that yet until we set up auto changelogs on release, badges will now display the package version which can be incremented by each PR into main. 

I am going to assume that we will transition into a `staging-> production` format where main will be reserved for each release and sets of PRs will be made into a `staging` branch before going out as a release in `main`. This has not been something we have been doing up to this point due to the early nature of the project. 