### PR TITLE
fixing return types of some methods and updating their docstrings

### DIFF
--- a/src/dynode/abstract_initializer.py
+++ b/src/dynode/abstract_initializer.py
@@ -8,6 +8,8 @@ to produce an initial state representing some analyzed population
 from abc import ABC, abstractmethod
 from typing import Any
 
+from numpy import ndarray
+
 from . import SEIC_Compartments, utils
 
 
@@ -35,22 +37,23 @@ class AbstractInitializer(ABC):
         assert self.INITIAL_STATE is not None
         return self.INITIAL_STATE
 
-    def load_initial_population_fractions(self) -> None:
+    def load_initial_population_fractions(self) -> ndarray:
         """
-        loads age demographics for the US and
-        sets the inital population fraction by age bin.
+        Loads age demographics for the specified region and
+        returns the inital population fraction by age bin.
 
-        Updates
+        Returns
         ----------
-        `self.config.INITIAL_POPULATION_FRACTIONS` : numpy.ndarray
-            proportion of the total population that falls into each age group,
-            length of this array is equal the number of age groups sums to 1.0.
+        numpy.ndarray
+            Proportion of the total population that falls into each age group,
+            `len(self.load_initial_population_fractions()) == self.config.NUM_AGE_GROUPS`
+            `np.sum(self.load_initial_population_fractions()) == 1.0
         """
         populations_path = (
             self.config.DEMOGRAPHIC_DATA_PATH
             + "population_rescaled_age_distributions/"
         )
         # TODO support getting more regions than just 1
-        self.config.INITIAL_POPULATION_FRACTIONS = utils.load_age_demographics(
+        return utils.load_age_demographics(
             populations_path, self.config.REGIONS, self.config.AGE_LIMITS
         )[self.config.REGIONS[0]]

--- a/src/dynode/abstract_parameters.py
+++ b/src/dynode/abstract_parameters.py
@@ -482,14 +482,16 @@ class AbstractParameters:
             )
         )
 
-    def retrieve_population_counts(self) -> None:
-        """
-        A wrapper function which takes calculates the age stratified population counts across all the INITIAL_STATE compartments
-        (minus the book-keeping C compartment.) and stores it in the self.config.POPULATION parameter.
+    def retrieve_population_counts(self) -> np.ndarray:
+        """Calculates the age stratified population counts across all tracked
+        self.INITIAL_STATE compartments, excluding the book-keeping C compartment.
 
-        We do not recieve this data exactly from the initializer, but it is trivial to recalculate.
+        Returns
+        -------
+        np.ndarray
+            population counts of each age bin within `self.INITIAL_STATE`
         """
-        self.config.POPULATION = np.sum(  # sum together S+E+I compartments
+        return np.sum(  # sum together S+E+I compartments
             np.array(
                 [
                     np.sum(
@@ -526,10 +528,8 @@ class AbstractParameters:
             containing the relative immune escape values for each challenging
             strain compared to each prior immune history in the model.
         """
-        self.config.CROSSIMMUNITY_MATRIX = (
-            utils.strain_interaction_to_cross_immunity(
-                self.config.NUM_STRAINS, self.config.STRAIN_INTERACTIONS
-            )
+        return utils.strain_interaction_to_cross_immunity(
+            self.config.NUM_STRAINS, self.config.STRAIN_INTERACTIONS
         )
 
     def load_vaccination_model(self) -> None:
@@ -642,12 +642,10 @@ class AbstractParameters:
             vax_knot_locations[age_group_idx, vax_idx, :] = np.array(
                 knot_locations
             )
-        self.config.VACCINATION_MODEL_KNOTS = jnp.array(vax_knots)
-        self.config.VACCINATION_MODEL_KNOT_LOCATIONS = jnp.array(
-            vax_knot_locations
-        )
-        self.config.VACCINATION_MODEL_BASE_EQUATIONS = jnp.array(
-            vax_base_equations
+        return (
+            jnp.array(vax_knots),
+            jnp.array(vax_knot_locations),
+            jnp.array(vax_base_equations),
         )
 
     def seasonal_vaccination_reset(self, t: ArrayLike) -> ArrayLike:
@@ -699,7 +697,7 @@ class AbstractParameters:
             # if no seasonal vaccination, this function always returns zero
             return 0
 
-    def load_contact_matrix(self) -> None:
+    def load_contact_matrix(self) -> np.ndarray:
         """
         loads region specific contact matrix, usually sourced from
         https://github.com/mobs-lab/mixing-patterns
@@ -711,7 +709,7 @@ class AbstractParameters:
             where `CONTACT_MATRIX[i][j]` refers to the per capita
             interaction rate between age bin `i` and `j`
         """
-        self.config.CONTACT_MATRIX = utils.load_demographic_data(
+        return utils.load_demographic_data(
             self.config.DEMOGRAPHIC_DATA_PATH,
             self.config.REGIONS,
             self.config.NUM_AGE_GROUPS,

--- a/src/dynode/abstract_parameters.py
+++ b/src/dynode/abstract_parameters.py
@@ -510,7 +510,7 @@ class AbstractParameters:
             axis=(0),  # sum across compartments, keep age bins
         )
 
-    def load_cross_immunity_matrix(self) -> None:
+    def load_cross_immunity_matrix(self) -> jax.Array:
         """
         Loads the Crossimmunity matrix given the strain interactions matrix.
         Strain interactions matrix is a matrix of shape
@@ -520,11 +520,10 @@ class AbstractParameters:
         previously from a strain in dim 1. Neither the strain interactions matrix
         nor the crossimmunity matrix take into account waning.
 
-        Updates
+        Returns
         ----------
-        self.config.CROSSIMMUNITY_MATRIX:
-            updates this matrix to shape
-            (self.config.NUM_STRAINS, self.config.NUM_PREV_INF_HIST)
+        jax.Array
+            matrix of shape (self.config.NUM_STRAINS, self.config.NUM_PREV_INF_HIST)
             containing the relative immune escape values for each challenging
             strain compared to each prior immune history in the model.
         """
@@ -532,7 +531,7 @@ class AbstractParameters:
             self.config.NUM_STRAINS, self.config.STRAIN_INTERACTIONS
         )
 
-    def load_vaccination_model(self) -> None:
+    def load_vaccination_model(self) -> tuple[jax.Array, jax.Array, jax.Array]:
         """
         loads parameters of a polynomial spline vaccination model
         stratified on age bin and current vaccination status. Reads spline
@@ -545,7 +544,7 @@ class AbstractParameters:
         Raises `FileNotFoundError` if directory path does not contain region
         specific file matching expected naming convention.
 
-        UPDATES
+        Returns
         -----------
         the following are 3 parallel lists, each with leading dimensions
         `(NUM_AGE_GROUPS, MAX_VAX_COUNT+1)` identifying the vaccination spline
@@ -562,7 +561,6 @@ class AbstractParameters:
             array defining the coefficients (a,b,c,d) of each
             base equation `(a + b(t) + c(t)^2 + d(t)^3)` for the spline defined
             by `VACCINATION_MODEL_KNOT_LOCATIONS[i][j]`.
-
         """
         # if the user passes a directory instead of a file path
         # check to see if the state exists in the directory and use that

--- a/src/dynode/mechanistic_inferer.py
+++ b/src/dynode/mechanistic_inferer.py
@@ -46,18 +46,31 @@ class MechanisticInferer(AbstractParameters):
         self.runner = runner
         self.INITIAL_STATE = initial_state
         self.infer_complete = False
-        self.set_infer_algo()
-        self.retrieve_population_counts()
-        self.load_vaccination_model()
-        self.load_contact_matrix()
+        # set inference algo to mcmc
+        self.inference_algo = self.set_infer_algo()
+        # retrieve population age distribution via passed initial state
+        self.config.POPULATION = self.retrieve_population_counts()
+        # load all vaccination splines
+        self.config.VACCINATION_MODEL_KNOTS,
+        self.config.VACCINATION_MODEL_KNOT_LOCATIONS,
+        self.config.VACCINATION_MODEL_BASE_EQUATIONS = (
+            self.load_vaccination_model()
+        )
+        self.config.CONTACT_MATRIX = self.load_contact_matrix()
 
-    def set_infer_algo(self, inferer_type: str = "mcmc") -> None:
-        """Sets the inferer's inference algorithm and sampler.
+    def set_infer_algo(self, inferer_type: str = "mcmc") -> MCMC:
+        """returns inference algorithm with attached sampler.
 
         Parameters
         ----------
         inferer_type : str, optional
             infer algo you wish to use, by default "mcmc"
+
+        Returns
+        ----------
+        MCMC
+            returns MCMC inference algorithm as it is the only supported
+            algorithm currently
 
         Raises
         ------
@@ -75,7 +88,7 @@ class MechanisticInferer(AbstractParameters):
         if inferer_type == "mcmc":
             # default to max tree depth of 5 if not specified
             tree_depth = getattr(self.config, "MAX_TREE_DEPTH", 5)
-            self.inference_algo = MCMC(
+            return MCMC(
                 NUTS(
                     self.likelihood,
                     dense_mass=True,

--- a/src/dynode/mechanistic_inferer.py
+++ b/src/dynode/mechanistic_inferer.py
@@ -51,11 +51,11 @@ class MechanisticInferer(AbstractParameters):
         # retrieve population age distribution via passed initial state
         self.config.POPULATION = self.retrieve_population_counts()
         # load all vaccination splines
-        self.config.VACCINATION_MODEL_KNOTS,
-        self.config.VACCINATION_MODEL_KNOT_LOCATIONS,
-        self.config.VACCINATION_MODEL_BASE_EQUATIONS = (
-            self.load_vaccination_model()
-        )
+        (
+            self.config.VACCINATION_MODEL_KNOTS,
+            self.config.VACCINATION_MODEL_KNOT_LOCATIONS,
+            self.config.VACCINATION_MODEL_BASE_EQUATIONS,
+        ) = self.load_vaccination_model()
         self.config.CONTACT_MATRIX = self.load_contact_matrix()
 
     def set_infer_algo(self, inferer_type: str = "mcmc") -> MCMC:

--- a/src/dynode/static_value_parameters.py
+++ b/src/dynode/static_value_parameters.py
@@ -23,10 +23,13 @@ class StaticValueParameters(AbstractParameters):
         self.config = Config(global_json).add_file(runner_json)
         self.INITIAL_STATE = INITIAL_STATE
         # load self.config.POPULATION
-        self.retrieve_population_counts()
+        self.config.POPULATION = self.retrieve_population_counts()
         # load self.config.VACCINATION_MODEL_KNOTS/
         # VACCINATION_MODEL_KNOT_LOCATIONS/VACCINATION_MODEL_BASE_EQUATIONS
-        self.load_vaccination_model()
-        # load self.config.CONTACT_MATRIX
-        self.load_contact_matrix()
-        # rest of the work is handled by the AbstractParameters
+        # load all vaccination splines
+        self.config.VACCINATION_MODEL_KNOTS,
+        self.config.VACCINATION_MODEL_KNOT_LOCATIONS,
+        self.config.VACCINATION_MODEL_BASE_EQUATIONS = (
+            self.load_vaccination_model()
+        )
+        self.config.CONTACT_MATRIX = self.load_contact_matrix()

--- a/src/dynode/static_value_parameters.py
+++ b/src/dynode/static_value_parameters.py
@@ -27,9 +27,9 @@ class StaticValueParameters(AbstractParameters):
         # load self.config.VACCINATION_MODEL_KNOTS/
         # VACCINATION_MODEL_KNOT_LOCATIONS/VACCINATION_MODEL_BASE_EQUATIONS
         # load all vaccination splines
-        self.config.VACCINATION_MODEL_KNOTS,
-        self.config.VACCINATION_MODEL_KNOT_LOCATIONS,
-        self.config.VACCINATION_MODEL_BASE_EQUATIONS = (
-            self.load_vaccination_model()
-        )
+        (
+            self.config.VACCINATION_MODEL_KNOTS,
+            self.config.VACCINATION_MODEL_KNOT_LOCATIONS,
+            self.config.VACCINATION_MODEL_BASE_EQUATIONS,
+        ) = self.load_vaccination_model()
         self.config.CONTACT_MATRIX = self.load_contact_matrix()


### PR DESCRIPTION
many methods were updating `self` instead of returning the value, this is bad practice as it is a side effect and means the order in which methods are run can change results. This also had direct impacts on the effort to refactor method docstrings as `Modifies` is not a section in the numpy format.

Merging this PR in with #323 so that further docstring compliance can be done with the new method headers.