### PR TITLE
formatting comments on python scripts outside of src/

### DIFF
--- a/data_manipulation_scripts/sim_data_to_sero_generator.py
+++ b/data_manipulation_scripts/sim_data_to_sero_generator.py
@@ -1,3 +1,5 @@
+"""A script designed to generate a sample population from ABM output."""
+
 import datetime
 import sqlite3
 
@@ -164,7 +166,7 @@ infection_history_by_infected = infection_history_by_infected.drop(
 
 
 #### REPLACE EMPTY SET WITH NONE  #################################
-def replace_empty_set_with_none(input_set):
+def _replace_empty_set_with_none(input_set):
     if len(input_set) == 0:
         return ""
     else:
@@ -173,7 +175,7 @@ def replace_empty_set_with_none(input_set):
 
 infection_history_by_infected["strains"] = infection_history_by_infected[
     "strains"
-].apply(replace_empty_set_with_none)
+].apply(_replace_empty_set_with_none)
 
 infection_history_by_infected.to_csv(OUTPUT_DATA_PATH, index=False)
 

--- a/examples/example_end_to_end_run.py
+++ b/examples/example_end_to_end_run.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """A basic covid example to show off how to work with DynODE.
 
 Results produced by this basic example are not meant to be taken as serious
@@ -10,8 +11,6 @@ estimates of what epidemiological variables produced it.
 For runtime the fitting is very short and not very accurate, you may improve
 the accuracy at the cost of runtime by modifying the inferer config.
 """
-
-#!/usr/bin/env python
 
 import argparse
 import os

--- a/examples/example_end_to_end_run.py
+++ b/examples/example_end_to_end_run.py
@@ -1,14 +1,17 @@
-#!/usr/bin/env python
-"""
-A basic local covid example meant to show off the flow of running the mechanistic model
+"""A basic covid example to show off how to work with DynODE.
 
-Results produced by this basic example are not meant to be taken as serious predictions, but rather
-a demonstration with synthetic data.
+Results produced by this basic example are not meant to be taken as serious
+predictions, but rather a demonstration with synthetic data.
 
 To see a image detailing the output of a single run, if you set the --infer flag
 this script will generate some example output, and then fit back onto it with some broad prior
 estimates of what epidemiological variables produced it.
+
+For runtime the fitting is very short and not very accurate, you may improve
+the accuracy at the cost of runtime by modifying the inferer config.
 """
+
+#!/usr/bin/env python
 
 import argparse
 import os
@@ -39,18 +42,22 @@ parser.add_argument(
 
 
 class ExampleDynodeRunner(AbstractDynodeRunner):
+    """An Example DynODE Runner used to launch this illustration."""
+
     def process_state(self, state: str, **kwargs):
-        """An example of a method used to process a single state using DynODE
+        """Every DynODE runner must have an entry point.
+
         In this case the example configs are built around US data, so we are
         running the whole US as a single entity.
 
         Parameters
         ----------
         state : str
-            state USPS, ignored in this specific example
+            State USPS, ignored in this specific example as it only runs USA.
         infer : bool, optional
-            whether or not the user of this example script wants to run inference,
-            by default False
+            Whether or not the user of this example script wants to run inference,
+            by default False. Stored in kwargs to align with
+            `AbstractDynodeRunner` function signature.
         """
         infer = bool(kwargs["infer"])
         # step 1: define your paths


### PR DESCRIPTION
making sure `pydocstyle` passes all python scripts in the whole repo, as opposed to just the ones in `src/`. This is mentioned in #332 to ensure that running `pydocstyle convention=numpy .` passes.

