### PR TITLE
constraining versioning, removing unneeded packages, fixing mypy

### DIFF
--- a/examples/example_end_to_end_run.py
+++ b/examples/example_end_to_end_run.py
@@ -99,6 +99,9 @@ class ExampleDynodeRunner(AbstractDynodeRunner):
             # for an example inference, lets jumble our solution up a bit and attempt to fit back to it
             # apply an age specific IHR to the infection incidence to get hospitalization incidence
             ihr = [0.002, 0.004, 0.008, 0.06]
+            assert (
+                solution.ys is not None
+            ), "solution.ys returned None, odes failed."
             model_incidence = np.sum(solution.ys[3], axis=(2, 3, 4))
             model_incidence = np.diff(model_incidence, axis=0)
             # noise our "hospitalization" data with a negative binomial distribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2024.02.06.2a"
+version = "2024.02.07.2a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ docker = "7.1.*"
 
 [tool.poetry.group.dev.dependencies]
 pandas-stubs = "2.2.*"
-#bayeux-ml = "0.1.*"
 pydocstyle = "6.3.*"
 mypy = "1.11.*"
 pytest = "8.3.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2024.02.06.1a"
+version = "2024.02.06.2a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"
@@ -8,28 +8,27 @@ readme = "README.md"
 package-mode = true
 
 [tool.poetry.dependencies]
-python = "^3.10"
-diffrax = "0.5.0"
-jax = "<=0.4.26"
-jaxlib = "<=0.4.26"
-matplotlib = ">=3.7.2"
-numpy = ">=1.25.2"
-numpyro = ">=0.13.2"
-pandas = ">=2.0.3"
-seaborn = ">=0.13.2"
-pytest = ">=7.4.0"
-pip = "^24.0"
-epiweeks = "^2.3.0"
-pre-commit = "^3.7.1"
-mypy = "^1.10.0"
-requests = "^2.32.3"
-docker = "^7.1.0"
-bayeux-ml = "^0.1.14"
-pydocstyle = "^6.3.0"
+python = "3.10.*"
+diffrax = "0.5.*"
+jax = "0.4.*"
+jaxlib = "0.4.*"
+matplotlib = "3.9.*"
+numpy = "2.0.*"
+numpyro = "0.15.*"
+pandas = "2.2.*"
+seaborn = "0.13.*"
+pip = "24.2.*"
+epiweeks = "2.3.*"
+docker = "7.1.*"
 
 
 [tool.poetry.group.dev.dependencies]
-pandas-stubs = "^2.2.3.241126"
+pandas-stubs = "2.2.*"
+#bayeux-ml = "0.1.*"
+pydocstyle = "6.3.*"
+mypy = "1.11.*"
+pytest = "8.3.*"
+pre-commit = "3.8.*"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/dynode/dynode_runner.py
+++ b/src/dynode/dynode_runner.py
@@ -350,17 +350,14 @@ class AbstractDynodeRunner(ABC):
         )
         for (chain, particle), sol_dct in posteriors.items():
             # content of `sol_dct` depends on return value of inferer.run_simulation func
-            infection_timeseries_tmp = sol_dct["solution"]
-            assert isinstance(infection_timeseries_tmp, Solution)
-            infection_timeseries: Solution = infection_timeseries_tmp
+            assert isinstance(sol_dct["solution"], Solution)
+            infection_timeseries: Solution = sol_dct["solution"]
 
-            hospitalizations_tmp = sol_dct["hospitalizations"]
-            assert isinstance(hospitalizations_tmp, Array)
-            hospitalizations: Array = hospitalizations_tmp
+            assert isinstance(sol_dct["hospitalizations"], Array)
+            hospitalizations: Array = sol_dct["hospitalizations"]
 
-            posterior_parameters_tmp = sol_dct["parameters"]
-            assert isinstance(posterior_parameters_tmp, dict)
-            posterior_parameters: dict[str, Array] = posterior_parameters_tmp
+            assert isinstance(sol_dct["parameters"], dict)
+            posterior_parameters: dict[str, Array] = sol_dct["parameters"]
             # spoof the inferer to return our posterior parameters
             # when calling `get_parameters()` instead of trying to sample.
             # TODO fix this flow to not use spoofing.

--- a/src/dynode/dynode_runner.py
+++ b/src/dynode/dynode_runner.py
@@ -350,10 +350,14 @@ class AbstractDynodeRunner(ABC):
         )
         for (chain, particle), sol_dct in posteriors.items():
             # content of `sol_dct` depends on return value of inferer.run_simulation func
-            infection_timeseries: Solution = sol_dct["solution"]
+            infection_timeseries_tmp = sol_dct["solution"]
+            assert isinstance(infection_timeseries_tmp, Solution)
+            infection_timeseries: Solution = infection_timeseries_tmp
+
             hospitalizations_tmp = sol_dct["hospitalizations"]
             assert isinstance(hospitalizations_tmp, Array)
             hospitalizations: Array = hospitalizations_tmp
+
             posterior_parameters_tmp = sol_dct["parameters"]
             assert isinstance(posterior_parameters_tmp, dict)
             posterior_parameters: dict[str, Array] = posterior_parameters_tmp
@@ -461,6 +465,9 @@ class AbstractDynodeRunner(ABC):
             timeseries of interest involving model output.
         """
         compartment_timeseries = solution.ys
+        assert (
+            compartment_timeseries is not None
+        ), "solution.ys returned None, odes failed."
         num_days_predicted = compartment_timeseries[
             model.config.COMPARTMENT_IDX.S
         ].shape[0]

--- a/src/dynode/mechanistic_inferer.py
+++ b/src/dynode/mechanistic_inferer.py
@@ -7,7 +7,6 @@ import datetime
 import json
 from typing import Union
 
-# import bayeux as bx
 import jax.numpy as jnp
 import jax.typing
 import numpy as np

--- a/src/dynode/mechanistic_inferer.py
+++ b/src/dynode/mechanistic_inferer.py
@@ -7,7 +7,7 @@ import datetime
 import json
 from typing import Union
 
-import bayeux as bx
+# import bayeux as bx
 import jax.numpy as jnp
 import jax.typing
 import numpy as np
@@ -139,6 +139,9 @@ class MechanisticInferer(AbstractParameters):
         """
         # add 1 to idxs because we are stratified by time in the solution object
         # sum down to just time x age bins
+        assert (
+            solution.ys is not None
+        ), "solution.ys returned None, odes failed."
         model_incidence = jnp.sum(
             solution.ys[self.config.COMPARTMENT_IDX.C],
             axis=(
@@ -245,28 +248,6 @@ class MechanisticInferer(AbstractParameters):
         self.infer_complete = True
         return self.inference_algo
 
-    def _debug_likelihood(self, **kwargs) -> bx.Model:
-        """EXPERIMENTAL function recreates `self.likelihood` for basic sanity checking.
-
-        Passes all parameters given to it to `self.likelihood`,
-        initializes with `self.INITIAL_STATE`
-        and passes `self.config.INFERENCE_PRNGKEY` as seed for randomness.
-
-        Returns
-        -------
-        Bayeux.Model
-            Model object used to debug.
-        """
-        bx_model = bx.Model.from_numpyro(
-            jax.tree_util.Partial(self.likelihood, **kwargs),
-            # this does not work for non-one/sampled self.INITIAL_INFECTIONS_SCALE
-            initial_state=self.INITIAL_STATE,
-        )
-        bx_model.mcmc.numpyro_nuts.debug(
-            seed=PRNGKey(self.config.INFERENCE_PRNGKEY)
-        )
-        return bx_model
-
     def _checkpoint_compartment_sizes(self, solution: Solution):
         """Take note of compartment sizes at end of `solution` and on key dates.
 
@@ -283,6 +264,9 @@ class MechanisticInferer(AbstractParameters):
             a diffrax Solution object returned by solving ODEs, most often
             retrieved by `self.run_simulation()`
         """
+        assert (
+            solution.ys is not None
+        ), "solution.ys returned None, odes failed."
         for compartment in self.config.COMPARTMENT_IDX:
             numpyro.deterministic(
                 "final_timestep_%s" % compartment.name,

--- a/src/dynode/mechanistic_runner.py
+++ b/src/dynode/mechanistic_runner.py
@@ -8,6 +8,7 @@ import jax
 import jax.numpy as jnp
 import numpyro  # type: ignore
 from diffrax import (  # type: ignore
+    AbstractStepSizeController,
     ConstantStepSize,
     ODETerm,
     PIDController,
@@ -104,6 +105,7 @@ class MechanisticRunner:
         # jump_ts describe points in time where the model is not fully differentiable
         # this is often due to piecewise changes in parameter values like Beta
         # this is why many functions in the runner/params are required to be continuously differentiable.
+        stepsize_controller: AbstractStepSizeController
         if "CONSTANT_STEP_SIZE" in args.keys() and args["CONSTANT_STEP_SIZE"]:
             dt0 = args["CONSTANT_STEP_SIZE"]
             # if user specifies they want constant step size, set it here
@@ -111,7 +113,7 @@ class MechanisticRunner:
             print("using Constant Step Size ODES with size %s" % (str(dt0)))
         else:  # otherwise use adaptive step size.
             jump_ts = (
-                list(args["BETA_TIMES"])
+                jnp.array(list(args["BETA_TIMES"]))
                 if "BETA_TIMES" in args.keys()
                 else None
             )

--- a/tests/test_inferer.py
+++ b/tests/test_inferer.py
@@ -46,6 +46,9 @@ synthetic_solution = runner.run(
     args=static_params.get_parameters(),
 )
 ihr = [0.002, 0.004, 0.008, 0.06]
+assert (
+    synthetic_solution.ys is not None
+), "solution.ys returned None, odes failed."
 model_incidence = jnp.sum(synthetic_solution.ys[3], axis=(2, 3, 4))
 model_incidence = jnp.diff(model_incidence, axis=0)
 synthetic_hosp_obs = jnp.rint(np.asarray(model_incidence) * ihr).astype(int)
@@ -175,10 +178,3 @@ def test_random_sampling_across_chains_and_particles():
             "Unable to run all tests within test_random_sampling_across_chains_and_particles "
             "since you have only one chain! check test_config_inferer.json"
         )
-
-
-def test_debug_inferer():
-    """A simple test to make sure the _debug_likelihood function does not explode and correctly passes kwargs"""
-    inferer._debug_likelihood(
-        tf=len(synthetic_hosp_obs), obs_metrics=synthetic_hosp_obs
-    )


### PR DESCRIPTION
constrained all packages to current working major version, wildcarding minor versions to allow bug fixes.

As a result of minor version wildcard some type hinting also required fixing.

Removed Bayeux package as it was only used in a single function which was not useful to modelers.