### PR TITLE
automatic tagging of pushes to `development` or `main` branches

### DIFF
--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -1,0 +1,36 @@
+name: Tagging
+
+on:
+  push:
+    branches:
+      - development
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install toml  # Install toml package to read pyproject.toml
+
+      - name: Get version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['tool']['poetry']['version'])")
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Create Tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git tag "$VERSION"
+          git push origin "$VERSION"


### PR DESCRIPTION
adds github workflow to auto-tag any PRs into "development" or "main"

CLOSES #336 
