### PR TITLE
updating `dynode` version for new tag with pydantic configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
+## [2024.02.25.1a] - Pydantic Config Groundwork
+### Added
+- The `src/dynode/model_configuration` module for creation of Python config classes to initialize the new DynODE framework.
+
+### Changed
+- Nothing yet, as the new DynODE framework is written it will reference the new config classes instead of old structure.
+
+### Deprecated
+- Old `config.py` file within `src/dynode`
+
+### Removed
+
+### Fixed
+
+---
+
+
 ## [2024.02.06.0a] - DynODE Evolution Initialization
 ### Added
 - Added this changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2024.02.07.2a"
+version = "2024.02.25.1a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"


### PR DESCRIPTION
I realized that the #351 PR did not update the DynODE version or add a CHANGELOG entry. I went ahead and did that so our auto-tagger will work.