### PR TITLE
adding `PosteriorSample()` helper type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
-## [2024.02.25.2a] - PosteriorSample distribution
+## [2024.02.26.1a] - PosteriorSample distribution
 ### Added
 - A `types.py` module for declaring types to be used within DynODE config files.
 - A `PosteriorSample` class within `dynode.model_configuration.types` meant to identify parameters whose values will be replaced by a Posterior sample from a previous fit of the model.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
+## [2024.02.25.2a] - PosteriorSample distribution
+### Added
+- A `types.py` module for declaring types to be used within DynODE config files.
+- A `PosteriorSample` class within `dynode.model_configuration.types` meant to identify parameters whose values will be replaced by a Posterior sample from a previous fit of the model.
+
+---
+
 ## [2024.02.25.1a] - Pydantic Config Groundwork
 ### Added
 - The `src/dynode/model_configuration` module for creation of Python config classes to initialize the new DynODE framework.
@@ -24,7 +31,6 @@ no suffix when releases and the staging branch is pulled into the release branch
 ### Fixed
 
 ---
-
 
 ## [2024.02.06.0a] - DynODE Evolution Initialization
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
+## [2024.02.25.1a] - Pydantic Config Groundwork
+### Added
+- The `src/dynode/model_configuration` module for creation of Python config classes to initialize the new DynODE framework.
+
+### Changed
+- Nothing yet, as the new DynODE framework is written it will reference the new config classes instead of old structure.
+
+### Deprecated
+- Old `config.py` file within `src/dynode`
+
+### Removed
+
+### Fixed
+
+---
+
+
 ## [2024.02.06.0a] - DynODE Evolution Initialization
 ### Added
 - Added this changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2024.02.25.2a"
+version = "2024.02.26.1a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2024.02.25.1a"
+version = "2024.02.25.2a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2024.02.07.2a"
+version = "2024.02.25.1a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/src/dynode/model_configuration/types.py
+++ b/src/dynode/model_configuration/types.py
@@ -14,7 +14,7 @@ class PosteriorSample(dist.Distribution):
 
     def __init__(self):
         """Create a placeholder PosteriorSample distribution."""
-        super(PosteriorSample, self).__init__()
+        super().__init__()
 
     def sample(self, _, sample_shape=()):
         """Retrieve sample from a Posterior distribution.
@@ -26,8 +26,8 @@ class PosteriorSample(dist.Distribution):
             numpyro.handlers.substitute() or numpyro.infer.Predictive.
         """
         raise SamplePosteriorError(
-            """Attempted to sample a PosteriorSample parameter outside of a
-            Predictive() context. This likely means you did not provide
-            posterior samples to the context via numpyro.infer.Predictive() or
-            numpyro.handlers.substitute()."""
+            "Attempted to sample a PosteriorSample parameter outside of a "
+            "Predictive() context. This likely means you did not provide "
+            "posterior samples to the context via numpyro.infer.Predictive() or "
+            "numpyro.handlers.substitute()."
         )

--- a/src/dynode/model_configuration/types.py
+++ b/src/dynode/model_configuration/types.py
@@ -1,0 +1,33 @@
+"""Module for declaring types to be used within DynODE config files."""
+
+import numpyro.distributions as dist
+
+
+class SamplePosteriorError(Exception):
+    """A special error raised if you attempt to randomly sample a deterministic posterior draw."""
+
+    pass
+
+
+class PosteriorSample(dist.Distribution):
+    """A parameter that draws its values from an external set of posterior samples."""
+
+    def __init__(self):
+        """Create a placeholder PosteriorSample distribution."""
+        super(PosteriorSample, self).__init__()
+
+    def sample(self, _, sample_shape=()):
+        """Retrieve sample from a Posterior distribution.
+
+        Raises
+        ------
+        SamplePosteriorError
+            if sample is called outside of an in-place substitute context like
+            numpyro.handlers.substitute() or numpyro.infer.Predictive.
+        """
+        raise SamplePosteriorError(
+            """Attempted to sample a PosteriorSample parameter outside of a
+            Predictive() context. This likely means you did not provide
+            posterior samples to the context via numpyro.infer.Predictive() or
+            numpyro.handlers.substitute()."""
+        )

--- a/src/dynode/model_configuration/types.py
+++ b/src/dynode/model_configuration/types.py
@@ -3,8 +3,8 @@
 import numpyro.distributions as dist
 
 
-class SamplePosteriorError(Exception):
-    """A special error raised if you attempt to randomly sample a deterministic posterior draw."""
+class SamplePlaceholderError(Exception):
+    """A special error raised if you attempt to randomly sample a placeholder variable."""
 
     pass
 
@@ -25,7 +25,7 @@ class PlaceholderSample(dist.Distribution):
             if sample is called outside of an in-place substitute context like
             numpyro.handlers.substitute() or numpyro.infer.Predictive.
         """
-        raise SamplePosteriorError(
+        raise SamplePlaceholderError(
             "Attempted to sample a PosteriorSample parameter outside of a "
             "Predictive() context. This likely means you did not provide "
             "posterior samples to the context via numpyro.infer.Predictive() or "

--- a/src/dynode/model_configuration/types.py
+++ b/src/dynode/model_configuration/types.py
@@ -9,15 +9,15 @@ class SamplePosteriorError(Exception):
     pass
 
 
-class PosteriorSample(dist.Distribution):
-    """A parameter that draws its values from an external set of posterior samples."""
+class PlaceholderSample(dist.Distribution):
+    """A parameter that draws its values from an external set of samples."""
 
     def __init__(self):
-        """Create a placeholder PosteriorSample distribution."""
+        """Create a PlaceholderSample distribution."""
         super().__init__()
 
     def sample(self, _, sample_shape=()):
-        """Retrieve sample from a Posterior distribution.
+        """Retrieve sample from an external set of samples.
 
         Raises
         ------


### PR DESCRIPTION
Often it is the case that modelers will want to run two separate models, one to fit to the data, and than another to project forward in time or run some scenarios. In these cases they need a way within their configuration files to mark that a particular parameter will depend on a set of posterior samples, usually from a previous run.

The `PosteriorSample` class offers an easy way for users to mark that a particular parameter's values will be deterministically picked from a set of posterior samples, while also quickly erroring if a user attempts to treat it as if it is a distribution they may randomly sample from.

Here is a basic example of the functionality:
```
import jax
import numpyro.distributions as dist
from numpyro.handlers import substitute
import numpyro
from dynode.model_configuration.types import PosteriorSample


def tester(distribution):
    """Sample a distribution"""
    rng_key = jax.random.PRNGKey(0)
    sample = numpyro.sample(
        "x", distribution, rng_key=rng_key
    )
    return sample

regular_dist = dist.Normal()
posterior_sample= PosteriorSample()

x_sample = tester(regular_dist)
>>> -0.7847657764467411

# wrap our tester method in a substitute call 
x_posterior = substitute(fn=lambda: tester(posterior_sample), data={"x": 1000})()
>>> 1000

# now no posterior context
x_error = tester(posterior_sample) 
>>> SamplePosteriorError: Attempted to sample a PosteriorSample parameter outside of a
            Predictive() context. This likely means you did not provide
            posterior samples to the context via numpyro.infer.Predictive() or
            numpyro.handlers.substitute().

```

in the backend the `PosteriorSample` class is treated just like a `numpyro.distributions.Distribution` object, however, when attempting to sample it outside of a `Predictive()` or `numpyro.handlers.substitute` context, the error will be raised immediately. 

In this example we use a site name `x` to identify the sampled parameter, however as long as we programmatically pick site names based on the parameter name, and users do not modify their `data` dictionary to mess with site names, this should properly match all parameters.

FYSA @kokbent @tjhladish @cdc-ap66 feel free to start a discussion below.

CLOSES #355 