### PR TITLE
updating `pytest` readme badge to track `dynode`

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -1,4 +1,4 @@
-name: Run pytest
+name: pytest
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FCDCgov%2FDynODE%2Frefs%2Fheads%2Fmain%2Fpyproject.toml&query=%24.tool.poetry.version&style=plastic&label=version&color=lightgray)
 ![pre-commit](https://github.com/CDCgov/dynode/workflows/pre-commit/badge.svg?style=plastic&link=https://github.com/CDCgov/dynode/actions/workflows/pre-commit.yaml)
-![CI](https://github.com/CDCgov/cfa_azure/workflows/Python%20Unit%20Tests%20with%20Coverage/badge.svg?style=plastic&link=https://github.com/CDCgov/cfa_azure/actions/workflows/pre-commit.yaml&link=https://github.com/CDCgov/cfa_azure/actions/workflows/ci.yaml)
+[![pytest](https://github.com/CDCgov/DynODE/actions/workflows/pytest.yaml/badge.svg)](https://github.com/CDCgov/DynODE/actions/workflows/pytest.yaml)
 ![GitHub License](https://img.shields.io/github/license/cdcgov/dynode?style=plastic&link=https://github.com/CDCgov/dynode/blob/master/LICENSE)
 ![Python](https://img.shields.io/badge/python-3670A0?logo=python&logoColor=ffdd54&style=plastic)
 


### PR DESCRIPTION
changing badge to actually follow dynode and renaming workflow to simply pytest.

Somehow when I first created the badges I was using `cfa_azure` badges to compare to and forgot to update one of them to track dynode instead of `cfa_azure`. Whoops.