### PR TITLE
bugfix of error when attempting to deepcopy a `SimulationDate`

### DIFF
--- a/src/dynode/_simulation_date.py
+++ b/src/dynode/_simulation_date.py
@@ -93,3 +93,7 @@ class SimulationDate(date):
     def __repr__(self):
         """Return a string representation of the SimulationDate."""
         return f"SimulationDate: ({self.year}-{self.month}-{self.day})({self.sim_day}) "
+
+    def __deepcopy__(self, memo):
+        """Return a deep copy of the SimulationDate."""
+        return SimulationDate(self.year, self.month, self.day)


### PR DESCRIPTION
fixing a bug where calling deep copy on a SimulationDate would incorrectly deep copy the object, specified an explicit __deepcopy__method to handle this.