### PR TITLE
fixing `scale_initial_infections` to preserve age distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
+## [2024.04.23.1a] - Static args support in `chex.Dataclass`
+### Changed
+- Changed `abstract_parameters.scale_initial_infections()` to preserve age distributions before and after scaling the number of initial infections. Before we were scaling E and I compartments and then scaling S down by the gained infections in E and I, without realizing that S/E/I had different age distributions individually.
+
 ## [2024.04.17.1a] - Static args support in `chex.Dataclass`
 ### Changed
 - Changed chex version to a custom fork that allows for static arguments within a chex dataclass. See branch [here](https://github.com/mishmish66/chex/tree/static_keynames) and PR describing functionality [here](https://github.com/google-deepmind/chex/pull/327). This is meant to be temporary until Chex merges the commit into main. They are however slow to update and I think this feature is important enough to justify merging the fork.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
-## [2024.04.23.1a] - Static args support in `chex.Dataclass`
+## [2024.04.23.1a] - Fixing `scale_initial_infections`
 ### Changed
 - Changed `abstract_parameters.scale_initial_infections()` to preserve age distributions before and after scaling the number of initial infections. Before we were scaling E and I compartments and then scaling S down by the gained infections in E and I, without realizing that S/E/I had different age distributions individually.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2024.04.17.1a"
+version = "2024.04.23.1a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -110,6 +110,33 @@ def test_scale_initial_infections():
             scale_factor,
             str(num_initial_infections_modified),
         )
+        # test that the age distributions are preserved
+        age_distributions_initial = jnp.sum(
+            jnp.array(
+                [
+                    jnp.sum(compartment, axis=(1, 2, 3))
+                    for compartment in static_params.INITIAL_STATE[:-1]
+                ]
+            ),
+            axis=0,
+        )
+        age_distributions_modified = jnp.sum(
+            jnp.array(
+                [
+                    jnp.sum(compartment, axis=(1, 2, 3))
+                    for compartment in modified_initial_state[:-1]
+                ]
+            ),
+            axis=0,
+        )
+        assert jnp.allclose(
+            age_distributions_initial, age_distributions_modified
+        ), (
+            f"the age distributions of the population were not preserved after "
+            f"scaling initial infections. Began with {age_distributions_initial} "
+            f"ended with {age_distributions_modified}"
+        )
+
         # test that the E and I ratios are preserved.
         for ratio_start, ratio_end in zip(
             [ratio_infections_exposed, ratio_infections_infectious],


### PR DESCRIPTION
### Changed
- Changed `abstract_parameters.scale_initial_infections()` to preserve age distributions before and after scaling the number of initial infections. Before we were scaling E and I compartments and then scaling S down by the gained infections in E and I, without realizing that S/E/I had different age distributions individually.
