### PR TITLE
disallowing duplicate compartment names in `SimulationConfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
+## [2025.06.03.2a] - disallowing duplicate compartment names in `SimulationConfig`
+### Changed
+- adding a validator to `SimulationConfig` that disallows compartments with the same names, as this breaks the `idx` enum and `get_compartment()` functions.
+
 ## [2025.06.01.3a] - patching a validator within `TransmissionParams`
 ### Changed
 - patching a hole in the `TransmissionParams` validator that allowed for poorly formatted `strain_interactions` dictionaries to make it through validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2025.06.01.3a"
+version = "2025.06.03.2a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/src/dynode/config/simulation_config.py
+++ b/src/dynode/config/simulation_config.py
@@ -207,6 +207,17 @@ class SimulationConfig(BaseModel):
         return compartments_namespace
 
     @model_validator(mode="after")
+    def _validate_no_shared_compartment_names(self) -> Self:
+        """Validate that no two compartments have the same name."""
+        compartment_names = [c.name for c in self.compartments]
+        assert len(set(compartment_names)) == len(compartment_names), (
+            f"you can not have two identically named compartments, "
+            f"found shared names: "
+            f"{set([x for x in compartment_names if compartment_names.count(x) > 1])}"
+        )
+        return self
+
+    @model_validator(mode="after")
     def _validate_shared_compartment_dimensions(self) -> Self:
         """Validate that any dimensions with same name across compartments are equal."""
         # quad-nested for loops are not ideal, but lists are very small so this should be fine


### PR DESCRIPTION
adding a validator to `SimulationConfig` that disallows compartments with the same names, as this breaks the `idx` enum and `get_compartment()` functions.