### PR TITLE
unit testing `dynode.config` sub-module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
+## [2025.06.04.1a] - unit testing `dynode.config` sub-module
+### Added
+- A boat load of unit tests for `dynode.config` submodule. This is not exhaustive and will likely be further expanded in the future
+
 ## [2025.06.03.2a] - disallowing duplicate compartment names in `SimulationConfig`
 ### Changed
 - adding a validator to `SimulationConfig` that disallows compartments with the same names, as this breaks the `idx` enum and `get_compartment()` functions.
-
 
 ## [2025.06.03.1a] - adding validators to catch empty `Strains` list cases
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2025.06.03.2a"
+version = "2025.06.04.1a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/src/dynode/config/__init__.py
+++ b/src/dynode/config/__init__.py
@@ -7,6 +7,7 @@ from .dimension import (
     FullStratifiedImmuneHistoryDimension,
     LastStrainImmuneHistoryDimension,
     VaccinationDimension,
+    WaneDimension,
 )
 from .initializer import Initializer
 from .params import (
@@ -28,6 +29,7 @@ __all__ = [
     "VaccinationDimension",
     "FullStratifiedImmuneHistoryDimension",
     "LastStrainImmuneHistoryDimension",
+    "WaneDimension",
     "Bin",
     "WaneBin",
     "DiscretizedPositiveIntBin",

--- a/tests/test_config/test_bins.py
+++ b/tests/test_config/test_bins.py
@@ -1,0 +1,35 @@
+import pytest
+from pydantic import ValidationError
+
+import dynode.config as config
+
+
+def test_descretized_int_bin():
+    """Test that the bin config is valid."""
+    try:
+        int_bin = config.DiscretizedPositiveIntBin(min_value=0, max_value=10)
+    except AssertionError:
+        pytest.fail(
+            "DiscretizedPositiveIntBin raised AssertionError unexpectedly!"
+        )
+    assert int_bin.min_value == 0
+    assert int_bin.max_value == 10
+
+
+def test_invalid_descretized_int_bin():
+    """Test that the bin config raises an error for invalid min/max."""
+    with pytest.raises(ValidationError):
+        config.DiscretizedPositiveIntBin(min_value=10, max_value=0)
+
+
+def test_dynode_name():
+    """Test that the bin config raises an error for invalid name."""
+    with pytest.raises(ValidationError):
+        config.Bin(name="1_invalid_name")
+
+    try:
+        valid_bin = config.Bin(name="valid_name")
+    except ValidationError:
+        pytest.fail("Bin raised ValueError unexpectedly for valid name!")
+
+    assert valid_bin.name == "valid_name"

--- a/tests/test_config/test_bins.py
+++ b/tests/test_config/test_bins.py
@@ -33,3 +33,30 @@ def test_dynode_name():
         pytest.fail("Bin raised ValueError unexpectedly for valid name!")
 
     assert valid_bin.name == "valid_name"
+
+
+def test_wane_bin():
+    """Test that the WaneBin config is valid."""
+    try:
+        wane_bin = config.WaneBin(
+            name="wane_bin", waiting_time=10.0, base_protection=0.8
+        )
+    except ValidationError:
+        pytest.fail("WaneBin raised ValidationError unexpectedly!")
+
+    assert wane_bin.name == "wane_bin"
+    assert wane_bin.waiting_time == 10.0
+    assert wane_bin.base_protection == 0.8
+
+
+def test_invalid_wane_bin_fields():
+    """Test that the WaneBin config raises an error for invalid base_protection or waiting_time."""
+    with pytest.raises(ValidationError):
+        config.WaneBin(
+            name="invalid_wane_bin", waiting_time=10.0, base_protection=1.2
+        )
+
+    with pytest.raises(ValidationError):
+        config.WaneBin(
+            name="invalid_wane_bin", waiting_time=-5.0, base_protection=0.8
+        )

--- a/tests/test_config/test_bins.py
+++ b/tests/test_config/test_bins.py
@@ -1,3 +1,5 @@
+import string
+
 import pytest
 from pydantic import ValidationError
 
@@ -22,17 +24,35 @@ def test_invalid_descretized_int_bin():
         config.DiscretizedPositiveIntBin(min_value=10, max_value=0)
 
 
+def test_invalid_descretized_int_bin_negatives():
+    with pytest.raises(ValidationError):
+        config.DiscretizedPositiveIntBin(min_value=-5, max_value=0)
+
+
 def test_dynode_name():
     """Test that the bin config raises an error for invalid name."""
-    with pytest.raises(ValidationError):
-        config.Bin(name="1_invalid_name")
-
     try:
         valid_bin = config.Bin(name="valid_name")
     except ValidationError:
         pytest.fail("Bin raised ValueError unexpectedly for valid name!")
 
     assert valid_bin.name == "valid_name"
+
+
+def test_invalid_dynode_names():
+    with pytest.raises(ValidationError):
+        # fails because not numeric
+        config.Bin(name="1_invalid_name")
+    with pytest.raises(ValidationError):
+        # fails due to space
+        config.Bin(name="invalid name")
+    # no special characters except underscore _
+    invalid_punctuation = list(string.punctuation)
+    invalid_punctuation.pop(invalid_punctuation.index("_"))
+    for char in invalid_punctuation:
+        # fails due to disallowed special char
+        with pytest.raises(ValidationError):
+            config.Bin(name=f"invalid{char}name")
 
 
 def test_wane_bin():

--- a/tests/test_config/test_compartment.py
+++ b/tests/test_config/test_compartment.py
@@ -1,0 +1,94 @@
+import jax.numpy as jnp
+import pytest
+from pydantic import ValidationError
+
+import dynode.config as config
+
+
+def test_compartment_valid():
+    """Test that the Compartment config is valid."""
+    try:
+        compartment = config.Compartment(
+            name="valid_compartment",
+            dimensions=[
+                config.Dimension(name="dim1", bins=[config.Bin(name="bin1")])
+            ],
+        )
+    except Exception as e:
+        pytest.fail(f"Compartment raised an exception unexpectedly: {e}")
+
+    assert compartment.name == "valid_compartment"
+    assert compartment.shape == (1,)
+    assert compartment.values == jnp.zeros((1,))
+    assert compartment.idx.dim1 == 0
+    assert compartment.idx.dim1.bin1 == 0
+
+
+def test_compartments_equal():
+    """Test that two compartments with the same name and dimensions are equal."""
+    compartment1 = config.Compartment(
+        name="compartment1",
+        dimensions=[
+            config.Dimension(name="dim1", bins=[config.Bin(name="bin1")])
+        ],
+    )
+    compartment2 = config.Compartment(
+        name="compartment1",
+        dimensions=[
+            config.Dimension(name="dim1", bins=[config.Bin(name="bin1")])
+        ],
+    )
+    assert (
+        compartment1 == compartment2
+    ), "Compartments with same name and dimensions should be equal"
+
+
+def test_compartments_different_names():
+    """Test that two compartments with different names are not equal."""
+    compartment1 = config.Compartment(
+        name="compartment1",
+        dimensions=[
+            config.Dimension(name="dim1", bins=[config.Bin(name="bin1")])
+        ],
+    )
+    compartment2 = config.Compartment(
+        name="compartment2",
+        dimensions=[
+            config.Dimension(name="dim1", bins=[config.Bin(name="bin1")])
+        ],
+    )
+    assert (
+        compartment1 != compartment2
+    ), "Compartments with different names should not be equal"
+
+
+def test_compartments_different_dimensions():
+    """Test that two compartments with different dimensions are not equal."""
+    compartment1 = config.Compartment(
+        name="compartment1",
+        dimensions=[
+            config.Dimension(name="dim1", bins=[config.Bin(name="bin1")])
+        ],
+    )
+    compartment2 = config.Compartment(
+        name="compartment1",
+        dimensions=[
+            config.Dimension(name="dim2", bins=[config.Bin(name="bin2")])
+        ],
+    )
+    assert (
+        compartment1 != compartment2
+    ), "Compartments with different dimensions should not be equal"
+
+
+def test_compartment_invalid_dimensions():
+    """Test that the Compartment config raises an error for invalid dimensions."""
+    with pytest.raises(ValidationError):
+        config.Compartment(
+            name="invalid_compartment",
+            dimensions=[
+                config.Dimension(name="dim1", bins=[config.Bin(name="bin1")]),
+                # Duplicate dimension name
+                config.Dimension(name="dim1", bins=[config.Bin(name="bin2")]),
+            ],
+        )

--- a/tests/test_config/test_compartment.py
+++ b/tests/test_config/test_compartment.py
@@ -82,7 +82,7 @@ def test_compartments_different_dimensions():
 
 
 def test_compartment_invalid_dimensions():
-    """Test that the Compartment config raises an error for invalid dimensions."""
+    """Test that the Compartment config raises an error for dimensions with the same name."""
     with pytest.raises(ValidationError):
         config.Compartment(
             name="invalid_compartment",

--- a/tests/test_config/test_deterministic_parameter.py
+++ b/tests/test_config/test_deterministic_parameter.py
@@ -1,6 +1,7 @@
 import pytest
 
 import dynode.config as config
+from dynode.infer import resolve_deterministic
 
 
 def test_deterministic_parameter():
@@ -22,6 +23,23 @@ def test_deterministic_parameter():
         param_state["dependent_param2"].resolve(param_state)
         == param_state["another_param"]
     )
+
+
+def test_resolve_deterministic():
+    param_state = {
+        "base_param": [1, 2, 3],
+        "another_param": 5,
+        "dependent_param": config.DeterministicParameter(
+            depends_on="base_param", index=1
+        ),
+        "dependent_param2": config.DeterministicParameter(
+            depends_on="another_param"
+        ),
+    }
+    param_state = resolve_deterministic(param_state, root_params=param_state)
+    # check that the replacement worked as expected.
+    assert param_state["dependent_param"] == param_state["base_param"][1]
+    assert param_state["dependent_param2"] == param_state["another_param"]
 
 
 def test_invalid_deterministic_parameter():

--- a/tests/test_config/test_deterministic_parameter.py
+++ b/tests/test_config/test_deterministic_parameter.py
@@ -1,0 +1,47 @@
+import pytest
+
+import dynode.config as config
+
+
+def test_deterministic_parameter():
+    """Test that the DeterministicParameter resolves correctly."""
+    param_state = {
+        "base_param": [1, 2, 3],
+        "another_param": 5,
+        "dependent_param": config.DeterministicParameter(
+            depends_on="base_param", index=1
+        ),
+        "dependent_param2": config.DeterministicParameter(
+            depends_on="another_param"
+        ),
+    }
+
+    resolved_value = param_state["dependent_param"].resolve(param_state)
+    assert resolved_value == param_state["base_param"][1]
+    assert (
+        param_state["dependent_param2"].resolve(param_state)
+        == param_state["another_param"]
+    )
+
+
+def test_invalid_deterministic_parameter():
+    """Test that the DeterministicParameter raises an error for invalid index."""
+    param_state = {
+        "base_param": [1, 2, 3],
+        "dependent_param": config.DeterministicParameter(
+            depends_on="base_param", index=3
+        ),
+        "dependent_param_key_error": config.DeterministicParameter(
+            depends_on="base_param", index=(1, 2)
+        ),
+        "dependent_param2": config.DeterministicParameter(
+            depends_on="missing_param"
+        ),
+    }
+
+    with pytest.raises(Exception):
+        param_state["dependent_param"].resolve(param_state)
+    with pytest.raises(Exception):
+        param_state["dependent_param_key_error"].resolve(param_state)
+    with pytest.raises(Exception):
+        param_state["dependent_param2"].resolve(param_state)

--- a/tests/test_config/test_dimension.py
+++ b/tests/test_config/test_dimension.py
@@ -1,0 +1,150 @@
+import pytest
+from pydantic import ValidationError
+
+import dynode.config as config
+
+
+def test_valid_dimension():
+    """Test that the Dimension config is valid."""
+    try:
+        dimension = config.Dimension(
+            name="valid_dimension", bins=[config.Bin(name="bin1")]
+        )
+    except Exception as e:
+        pytest.fail(f"Dimension raised an exception unexpectedly: {e}")
+
+    assert dimension.name == "valid_dimension"
+    assert len(dimension.bins) == 1
+    assert dimension.bins[0].name == "bin1"
+
+
+def test_mixed_type_bins():
+    """Test that Dimension raises an error for mixed type bins."""
+    with pytest.raises(ValidationError):
+        config.Dimension(
+            name="mixed_type_dimension",
+            bins=[
+                config.Bin(name="bin1"),
+                config.DiscretizedPositiveIntBin(min_value=0, max_value=10),
+            ],
+        )
+
+
+def test_empty_bins():
+    """Test that Dimension raises an error for empty bins."""
+    with pytest.raises(ValidationError):
+        config.Dimension(name="empty_bins_dimension", bins=[])
+
+
+def test_non_unique_bin_names():
+    """Test that Dimension raises an error for non-unique bin names."""
+    with pytest.raises(ValidationError):
+        config.Dimension(
+            name="non_unique_dimension",
+            bins=[
+                config.Bin(name="bin1"),
+                config.Bin(name="bin1"),  # Duplicate name
+            ],
+        )
+
+
+def test_discretized_int_bins_sorted():
+    """Test that Dimension with DiscretizedPositiveIntBin is sorted and has no gaps."""
+    try:
+        dimension = config.Dimension(
+            name="sorted_dimension",
+            bins=[
+                config.DiscretizedPositiveIntBin(min_value=0, max_value=10),
+                config.DiscretizedPositiveIntBin(min_value=11, max_value=20),
+            ],
+        )
+    except Exception as e:
+        pytest.fail(f"Dimension raised an exception unexpectedly: {e}")
+
+    assert len(dimension.bins) == 2
+    assert dimension.bins[0].min_value == 0
+    assert dimension.bins[1].min_value == 11
+
+
+def test_discretized_int_bins_overlap():
+    """Test that Dimension with overlapping DiscretizedPositiveIntBin raises an error."""
+    with pytest.raises(ValidationError):
+        config.Dimension(
+            name="overlapping_dimension",
+            bins=[
+                config.DiscretizedPositiveIntBin(min_value=0, max_value=10),
+                config.DiscretizedPositiveIntBin(min_value=5, max_value=15),
+            ],
+        )
+
+
+def test_discretized_int_bins_not_sorted():
+    """Test that Dimension with DiscretizedPositiveIntBin not sorted raises an error."""
+    with pytest.raises(ValidationError):
+        config.Dimension(
+            name="not_sorted_dimension",
+            bins=[
+                config.DiscretizedPositiveIntBin(min_value=11, max_value=20),
+                config.DiscretizedPositiveIntBin(min_value=0, max_value=10),
+            ],
+        )
+
+
+def test_discretized_int_bins_with_gaps():
+    """Test that Dimension with DiscretizedPositiveIntBin with gaps raises an error."""
+    with pytest.raises(ValidationError):
+        config.Dimension(
+            name="gaps_dimension",
+            bins=[
+                config.DiscretizedPositiveIntBin(min_value=0, max_value=10),
+                config.DiscretizedPositiveIntBin(min_value=12, max_value=20),
+            ],
+        )
+
+
+def test_vaccination_dimension():
+    """Test that the VaccinationDimension builder works correctly."""
+    num_shots = 2
+    try:
+        dimension = config.VaccinationDimension(
+            max_ordinal_vaccinations=num_shots,
+            seasonal_vaccination=False,
+        )
+    except Exception as e:
+        pytest.fail(
+            f"VaccinationDimension raised an exception unexpectedly: {e}"
+        )
+
+    assert dimension.name == "vax"
+    assert len(dimension.bins) == num_shots + 1  # +1 for the 0-shot bin
+    # assert dimension.seasonal_vaccination is False
+    assert dimension.bins[0].min_value == 0
+    assert dimension.bins[0].max_value == 0
+    assert dimension.bins[1].min_value == 1
+    assert dimension.bins[1].max_value == 1
+
+
+def test_vaccination_dimension_seasonal():
+    """Test that the VaccinationDimension builder works correctly."""
+    num_shots = 2
+    try:
+        dimension = config.VaccinationDimension(
+            max_ordinal_vaccinations=num_shots,
+            seasonal_vaccination=True,
+        )
+    except Exception as e:
+        pytest.fail(
+            f"VaccinationDimension raised an exception unexpectedly: {e}"
+        )
+
+    assert dimension.name == "vax"
+    assert len(dimension.bins) == num_shots + 2  # +1 for seasonal
+    # assert dimension.seasonal_vaccination is True
+    assert dimension.bins[0].min_value == 0
+    assert dimension.bins[0].max_value == 0
+    assert dimension.bins[1].min_value == 1
+    assert dimension.bins[1].max_value == 1
+    assert dimension.bins[2].min_value == 2
+    assert dimension.bins[2].max_value == 2
+    assert dimension.bins[3].min_value == 3
+    assert dimension.bins[3].max_value == 3

--- a/tests/test_config/test_dimension.py
+++ b/tests/test_config/test_dimension.py
@@ -124,6 +124,8 @@ def test_vaccination_dimension():
     assert dimension.bins[0].max_value == 0
     assert dimension.bins[1].min_value == 1
     assert dimension.bins[1].max_value == 1
+    assert dimension.bins[2].min_value == 2
+    assert dimension.bins[2].max_value == 2
 
 
 def test_vaccination_dimension_seasonal():

--- a/tests/test_config/test_params.py
+++ b/tests/test_config/test_params.py
@@ -41,16 +41,15 @@ def test_transmission_params_invalid_strain_interactions():
         config.TransmissionParams(
             strains=strains, strain_interactions=strain_interactions
         )
-    # Extra strain in interactions not in strains, TODO have this raise PR #420 fixes this
-    # strain_interactions = {
-    #     "strain1": {"strain1": 1.0, "strain2": 0.5, "strain3": 0.5},
-    #     "strain2": {"strain1": 0.5, "strain2": 1.0, "strain3": 0.5},
-    #     "strain3": {"strain1": 0.5, "strain2": 0.5, "strain3": 1.0},
-    # }
-    # with pytest.raises(ValidationError):
-    #     config.TransmissionParams(
-    #         strains=strains, strain_interactions=strain_interactions
-    #     )
+    strain_interactions = {
+        "strain1": {"strain1": 1.0, "strain2": 0.5, "strain3": 0.5},
+        "strain2": {"strain1": 0.5, "strain2": 1.0, "strain3": 0.5},
+        "strain3": {"strain1": 0.5, "strain2": 0.5, "strain3": 1.0},
+    }
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
 
 
 def test_transmission_params_inconsistent_strains():

--- a/tests/test_config/test_params.py
+++ b/tests/test_config/test_params.py
@@ -41,7 +41,7 @@ def test_transmission_params_invalid_strain_interactions():
         config.TransmissionParams(
             strains=strains, strain_interactions=strain_interactions
         )
-    # Extra strain in interactions not in strains, TODO have this raise
+    # Extra strain in interactions not in strains, TODO have this raise PR #420 fixes this
     # strain_interactions = {
     #     "strain1": {"strain1": 1.0, "strain2": 0.5, "strain3": 0.5},
     #     "strain2": {"strain1": 0.5, "strain2": 1.0, "strain3": 0.5},
@@ -51,3 +51,73 @@ def test_transmission_params_invalid_strain_interactions():
     #     config.TransmissionParams(
     #         strains=strains, strain_interactions=strain_interactions
     #     )
+
+
+def test_transmission_params_inconsistent_strains():
+    """Test that the TransmissionParams raises an error for inconsistent strains."""
+    strains = [
+        config.Strain(
+            strain_name="strain1",
+            r0=2,
+            infectious_period=5,
+            exposed_to_infectious=5.0,
+        ),
+        config.Strain(
+            strain_name="strain2", r0=2, infectious_period=5
+        ),  # missing exposed_to_infectious
+    ]
+    strain_interactions = {
+        "strain1": {"strain1": 1.0, "strain2": 0.5},
+        "strain2": {"strain1": 0.5, "strain2": 1.0},
+    }
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
+    # test again but with different field missing
+    strains = [
+        config.Strain(
+            strain_name="strain1",
+            r0=2,
+            infectious_period=5,
+            vaccine_efficacy={0: 0.8, 1: 0.9},
+        ),
+        config.Strain(
+            strain_name="strain2", r0=2, infectious_period=5
+        ),  # missing vaccine_efficacy
+    ]
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
+
+
+def test_solver_params():
+    """Test that the SolverParams config is valid."""
+    try:
+        solver_params = config.SolverParams(
+            max_steps=1000,
+            ode_solver_rel_tolerance=1e-6,
+            ode_solver_abs_tolerance=1e-9,
+        )
+    except ValidationError as e:
+        pytest.fail(f"SolverParams raised ValidationError unexpectedly: {e}")
+    assert solver_params.max_steps == 1000
+    assert solver_params.ode_solver_rel_tolerance == 1e-6
+    assert solver_params.ode_solver_abs_tolerance == 1e-9
+
+
+def test_solver_params_invalid():
+    """Test that the SolverParams raises an error for invalid parameters."""
+    with pytest.raises(ValidationError):
+        config.SolverParams(
+            max_steps=-1000,  # Invalid negative max_steps
+            ode_solver_rel_tolerance=1e-6,
+            ode_solver_abs_tolerance=1e-9,
+        )
+    with pytest.raises(ValidationError):
+        config.SolverParams(
+            max_steps=1000,
+            ode_solver_rel_tolerance=-1e-6,  # Invalid negative tolerance
+            ode_solver_abs_tolerance=1e-9,
+        )

--- a/tests/test_config/test_params.py
+++ b/tests/test_config/test_params.py
@@ -41,11 +41,50 @@ def test_transmission_params_invalid_strain_interactions():
         config.TransmissionParams(
             strains=strains, strain_interactions=strain_interactions
         )
+
+    strain_interactions = {
+        "strain1": {"strain1": 1.0, "strain2": 0.5},
+        # Missing entire row of strain_interactions matrix
+    }
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
     strain_interactions = {
         "strain1": {"strain1": 1.0, "strain2": 0.5, "strain3": 0.5},
         "strain2": {"strain1": 0.5, "strain2": 1.0, "strain3": 0.5},
+        # extra row in strain_interactions
         "strain3": {"strain1": 0.5, "strain2": 0.5, "strain3": 1.0},
     }
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
+
+
+def test_transmission_params_invalid_strains_list():
+    strains = []
+    strain_interactions = {
+        "strain1": {"strain1": 1.0, "strain2": 0.5},
+        "strain2": {"strain1": 0.5, "strain2": 1.5},
+    }
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
+    strains = [
+        config.Strain(strain_name="strain1", r0=2, infectious_period=5),
+        # missing a strain2
+    ]
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
+    strains = [
+        config.Strain(strain_name="strain1", r0=2, infectious_period=5),
+        # name mismatch
+        config.Strain(strain_name="NOTstrain2", r0=2, infectious_period=5),
+    ]
     with pytest.raises(ValidationError):
         config.TransmissionParams(
             strains=strains, strain_interactions=strain_interactions

--- a/tests/test_config/test_params.py
+++ b/tests/test_config/test_params.py
@@ -1,0 +1,53 @@
+import pytest
+from pydantic import ValidationError
+
+import dynode.config as config
+
+
+def test_transmission_params():
+    """Test that the TransmissionParams config is valid."""
+    strains = [
+        config.Strain(strain_name="strain1", r0=2, infectious_period=5),
+        config.Strain(strain_name="strain2", r0=2, infectious_period=5),
+    ]
+    strain_interactions = {
+        "strain1": {"strain1": 1.0, "strain2": 0.5},
+        "strain2": {"strain1": 0.5, "strain2": 1.0},
+    }
+    try:
+        transmission_params = config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
+    except ValidationError as e:
+        pytest.fail(
+            f"TransmissionParams raised ValidationError unexpectedly: {e}"
+        )
+
+    assert transmission_params.strains == strains
+    assert transmission_params.strain_interactions == strain_interactions
+
+
+def test_transmission_params_invalid_strain_interactions():
+    """Test that the TransmissionParams raises an error for invalid strain interactions."""
+    strains = [
+        config.Strain(strain_name="strain1", r0=2, infectious_period=5),
+        config.Strain(strain_name="strain2", r0=2, infectious_period=5),
+    ]
+    strain_interactions = {
+        "strain1": {"strain1": 1.0, "strain2": 0.5},
+        "strain2": {"strain1": 0.5},  # Missing interaction with strain2
+    }
+    with pytest.raises(ValidationError):
+        config.TransmissionParams(
+            strains=strains, strain_interactions=strain_interactions
+        )
+    # Extra strain in interactions not in strains, TODO have this raise
+    # strain_interactions = {
+    #     "strain1": {"strain1": 1.0, "strain2": 0.5, "strain3": 0.5},
+    #     "strain2": {"strain1": 0.5, "strain2": 1.0, "strain3": 0.5},
+    #     "strain3": {"strain1": 0.5, "strain2": 0.5, "strain3": 1.0},
+    # }
+    # with pytest.raises(ValidationError):
+    #     config.TransmissionParams(
+    #         strains=strains, strain_interactions=strain_interactions
+    #     )

--- a/tests/test_config/test_placeholder_sample.py
+++ b/tests/test_config/test_placeholder_sample.py
@@ -34,3 +34,12 @@ def test_placeholder_sample_substitution():
         ), "Substituted sample did not return expected value"
     except config.SamplePlaceholderError as e:
         pytest.fail(f"Substituted sample raised SamplePlaceholderError: {e}")
+
+
+def test_invalid_naming_placeholder_sample_substitution():
+    """Test that you must match the placeholder name in order to get a value."""
+    sample_with_substitute = substitute(
+        sample_placeholder, data={"NOTsample": 42}
+    )
+    with pytest.raises(config.SamplePlaceholderError):
+        sample_with_substitute()

--- a/tests/test_config/test_placeholder_sample.py
+++ b/tests/test_config/test_placeholder_sample.py
@@ -1,0 +1,36 @@
+import numpyro
+import pytest
+from numpyro.handlers import substitute
+
+import dynode.config as config
+
+
+def sample_placeholder():
+    return numpyro.sample("sample", config.PlaceholderSample())
+
+
+def test_placeholder_sample_create():
+    """Test that the PlaceholderSample config is valid."""
+    try:
+        config.PlaceholderSample()
+    except Exception as e:
+        pytest.fail(f"PlaceholderSample raised Exception unexpectedly: {e}")
+
+
+def test_placeholder_sample_errors_when_sampled_directly():
+    """Test that the PlaceholderSample raises an error when sampled directly."""
+    with pytest.raises(config.SamplePlaceholderError):
+        sample_placeholder()
+
+
+def test_placeholder_sample_substitution():
+    """Test that the PlaceholderSample can be substituted with a real sample."""
+    sample_with_substitute = substitute(
+        sample_placeholder, data={"sample": 42}
+    )
+    try:
+        assert (
+            sample_with_substitute() == 42
+        ), "Substituted sample did not return expected value"
+    except config.SamplePlaceholderError as e:
+        pytest.fail(f"Substituted sample raised SamplePlaceholderError: {e}")

--- a/tests/test_config/test_simulation_config.py
+++ b/tests/test_config/test_simulation_config.py
@@ -1,0 +1,176 @@
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+import dynode.config as config
+
+
+@pytest.fixture
+def c():
+    """Fixture for a valid simulation configuration."""
+    return config.SimulationConfig(
+        compartments=[
+            config.Compartment(
+                name="compartment1",
+                dimensions=[
+                    config.Dimension(
+                        name="dim1", bins=[config.Bin(name="bin1")]
+                    )
+                ],
+            )
+        ],
+        initializer=config.Initializer(
+            description="test initializer",
+            initialize_date=date(2022, 2, 11),
+            population_size=1000,
+        ),
+        parameters=config.Params(
+            transmission_params=config.TransmissionParams(
+                strains=[
+                    config.Strain(
+                        strain_name="strain1", r0=2, infectious_period=5
+                    )
+                ],
+                strain_interactions={"strain1": {"strain1": 1.0}},
+            ),
+            solver_params=config.SolverParams(),
+        ),
+    )
+
+
+def test_simulation_config_valid(c: config.SimulationConfig):
+    assert c is not None
+    assert len(c.compartments) == 1
+    assert c.idx.compartment1 == 0
+    assert c.idx.compartment1.dim1 == 0
+    assert c.idx.compartment1.dim1.bin1 == 0
+    assert c.parameters.transmission_params.strains[0].strain_name == "strain1"
+
+
+def test_flatten_bins(c: config.SimulationConfig):
+    """Test that flatten_bins returns the correct flattened bins."""
+    flattened_bins = c.flatten_bins()
+    assert len(flattened_bins) == 1
+    assert flattened_bins[0].name == "bin1"
+    c.compartments.append(
+        config.Compartment(
+            name="compartment2",
+            dimensions=[
+                config.Dimension(name="dim2", bins=[config.Bin(name="bin2")])
+            ],
+        )
+    )
+    flattened_dims = c.flatten_bins()
+    assert len(flattened_dims) == 2
+
+
+def test_flatten_dims(c: config.SimulationConfig):
+    """Test that flatten_dims returns the correct flattened dimensions."""
+    flattened_dims = c.flatten_dims()
+    assert len(flattened_dims) == 1
+    assert flattened_dims[0].name == "dim1"
+    c.compartments.append(
+        config.Compartment(
+            name="compartment2",
+            dimensions=[
+                config.Dimension(name="dim2", bins=[config.Bin(name="bin2")])
+            ],
+        )
+    )
+    flattened_dims = c.flatten_dims()
+    assert len(flattened_dims) == 2
+
+
+def test_get_compartment(c: config.SimulationConfig):
+    """Test that get_compartment returns the correct compartment."""
+    compartment = c.get_compartment("compartment1")
+    assert compartment.name == "compartment1"
+    # Should raise an error for non-existent compartment
+    with pytest.raises(AssertionError):
+        c.get_compartment("non_existent_compartment")
+
+
+def test_same_dim_names_different_bins(c: config.SimulationConfig):
+    """Test that compartments with the same dimension names but different bins are handled correctly."""
+    c.compartments.append(
+        config.Compartment(
+            name="compartment2",
+            dimensions=[
+                config.Dimension(name="dim1", bins=[config.Bin(name="bin2")])
+            ],
+        )
+    )
+    with pytest.raises(ValidationError):
+        # rerun the validators now that we have added the new compartment
+        c.model_validate(c)
+
+
+def test_same_dim_names_same_bins(c: config.SimulationConfig):
+    """Test that compartments with the same dimension names and bins are handled correctly."""
+    c.compartments.append(
+        config.Compartment(
+            name="compartment2",
+            dimensions=[
+                config.Dimension(name="dim1", bins=[config.Bin(name="bin1")])
+            ],
+        )
+    )
+    # rerun the validators now that we have added the new compartment
+    # Should not raise an error
+    c.model_validate(c)
+
+
+# does not pass for now, hotfixing
+# def test_same_compartment_names_errors(c: config.SimulationConfig):
+#     """Test that compartments with the same name raise an error."""
+#     c.compartments.append(
+#         config.Compartment(
+#             name="compartment1",  # Same name as existing compartment
+#             dimensions=[
+#                 config.Dimension(name="dim2", bins=[config.Bin(name="bin2")])
+#             ],
+#         )
+#     )
+#     with pytest.raises(ValidationError):
+#         # rerun the validators now that we have added the new compartment
+#         c.model_validate(c)
+
+
+def test_immune_history_compartment_validators(c: config.SimulationConfig):
+    """Test that SimulationConfig will raise an error if your immune history does
+    not correlate with the strains passed to TransmissionParams."""
+
+    c.compartments.append(
+        config.Compartment(
+            name="compartment2",
+            dimensions=[
+                config.LastStrainImmuneHistoryDimension(
+                    strains=[
+                        config.Strain(
+                            strain_name="strain1", r0=2, infectious_period=5
+                        )
+                    ],
+                )
+            ],
+        )
+    )
+    # should not raise because strain1 is in TransmissionParams
+    c.model_validate(c)
+    # now lets modify so the Dimension is using an incorrect strain
+    c.compartments[1] = config.Compartment(
+        name="compartment2",
+        dimensions=[
+            # purposely pass a strain that is not in TransmissionParams
+            config.LastStrainImmuneHistoryDimension(
+                strains=[
+                    config.Strain(
+                        strain_name="strain2", r0=2, infectious_period=5
+                    )
+                ],
+            )
+        ],
+    )
+    with pytest.raises(ValidationError):
+        # rerun the validators now that we have added the new compartment
+        c.model_validate(c)

--- a/tests/test_config/test_simulation_config.py
+++ b/tests/test_config/test_simulation_config.py
@@ -121,20 +121,19 @@ def test_same_dim_names_same_bins(c: config.SimulationConfig):
     c.model_validate(c)
 
 
-# does not pass for now, hotfixing
-# def test_same_compartment_names_errors(c: config.SimulationConfig):
-#     """Test that compartments with the same name raise an error."""
-#     c.compartments.append(
-#         config.Compartment(
-#             name="compartment1",  # Same name as existing compartment
-#             dimensions=[
-#                 config.Dimension(name="dim2", bins=[config.Bin(name="bin2")])
-#             ],
-#         )
-#     )
-#     with pytest.raises(ValidationError):
-#         # rerun the validators now that we have added the new compartment
-#         c.model_validate(c)
+def test_same_compartment_names_errors(c: config.SimulationConfig):
+    """Test that compartments with the same name raise an error."""
+    c.compartments.append(
+        config.Compartment(
+            name="compartment1",  # Same name as existing compartment
+            dimensions=[
+                config.Dimension(name="dim2", bins=[config.Bin(name="bin2")])
+            ],
+        )
+    )
+    with pytest.raises(ValidationError):
+        # rerun the validators now that we have added the new compartment
+        c.model_validate(c)
 
 
 def test_immune_history_compartment_validators(c: config.SimulationConfig):

--- a/tests/test_config/test_simulation_date.py
+++ b/tests/test_config/test_simulation_date.py
@@ -1,0 +1,93 @@
+from datetime import date
+
+import pytest
+from jax.random import PRNGKey
+from numpyro.distributions import Normal
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+import dynode.config as config
+
+
+def test_simulation_date():
+    """Test that the SimulationDate config is valid."""
+    try:
+        simulation_date = config.SimulationDate(2022, 2, 11)
+    except ValidationError as e:
+        pytest.fail(f"SimulationDate raised ValidationError unexpectedly: {e}")
+
+    assert simulation_date.year == 2022
+
+
+def test_simulation_date_without_dynode_flag():
+    simulation_date = config.SimulationDate(2022, 2, 11)
+    with pytest.raises(ValueError):
+        simulation_date.sim_day
+
+
+def test_simulation_date_with_dynode_flag():
+    simulation_date = config.SimulationDate(2022, 2, 11)
+    config.simulation_date.set_dynode_init_date_flag(date(2022, 2, 11))
+    sim_day = simulation_date.sim_day
+    assert (
+        sim_day == 0
+    ), "Sim day should be 0 when dynode init date flag is set to same day"
+
+
+def test_simulation_date_with_future_date():
+    simulation_date = config.SimulationDate(2022, 2, 11)
+    config.simulation_date.set_dynode_init_date_flag(date(2022, 2, 1))
+    sim_day = simulation_date.sim_day
+    assert (
+        sim_day == 10
+    ), "Sim day should be 0 when dynode init date flag is set to same day"
+
+
+def test_replace_simulation_dates_dict():
+    obj = {
+        "simulation_date": config.SimulationDate(2022, 2, 11),
+        "other_field": "test_value",
+    }
+    config.simulation_date.set_dynode_init_date_flag(date(2022, 2, 11))
+    obj = config.simulation_date.replace_simulation_dates(obj)
+    assert (
+        obj["simulation_date"] == 0
+    ), "replace_simuoation_dates is not finding SimulationDate objects correctly."
+
+
+def test_replace_simulation_dates_obj():
+    # make a test pydantic class to search
+    class test(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        simulation_date: config.SimulationDate
+
+    obj = test(simulation_date=config.SimulationDate(2022, 2, 11))
+    config.simulation_date.set_dynode_init_date_flag(date(2022, 2, 11))
+    obj = config.simulation_date.replace_simulation_dates(obj)
+    assert (
+        obj.simulation_date == 0
+    ), "replace_simuoation_dates is not finding SimulationDate objects correctly."
+
+
+def test_replace_simulation_dates_list():
+    obj = [config.SimulationDate(2022, 2, 11), "test_value"]
+    config.simulation_date.set_dynode_init_date_flag(date(2022, 2, 11))
+    obj = config.simulation_date.replace_simulation_dates(obj)
+    assert (
+        obj[0] == 0
+    ), "replace_simuoation_dates is not finding SimulationDate objects correctly."
+
+
+def test_replace_simulation_dates_distribution():
+    obj = Normal(loc=config.SimulationDate(2022, 2, 11), scale=1.0)
+    config.simulation_date.set_dynode_init_date_flag(date(2022, 2, 11))
+    obj: Normal = config.simulation_date.replace_simulation_dates(obj)
+    assert (
+        obj.loc == 0
+    ), "replace_simulation_dates is not finding SimulationDate objects correctly in distributions."
+
+    try:
+        obj.sample(key=PRNGKey(0))
+    except Exception as e:
+        pytest.fail(
+            f"Sampling from distribution with SimulationDate failed: {e}"
+        )

--- a/tests/test_config/test_simulation_date.py
+++ b/tests/test_config/test_simulation_date.py
@@ -1,3 +1,4 @@
+import os
 from datetime import date
 
 import pytest
@@ -6,6 +7,14 @@ from numpyro.distributions import Normal
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 import dynode.config as config
+
+
+@pytest.fixture(autouse=True)
+def setup_environment():
+    # to make sure the tests dont impact eachother, lets always clear
+    # the env flag before and after each test.
+    if f"DYNODE_INITIALIZATION_DATE({os.getpid()})" in os.environ:
+        del os.environ[f"DYNODE_INITIALIZATION_DATE({os.getpid()})"]
 
 
 def test_simulation_date():
@@ -19,6 +28,8 @@ def test_simulation_date():
 
 
 def test_simulation_date_without_dynode_flag():
+    # make sure the dynode initialization date flag is not set
+    # del os.environ[f"DYNODE_INITIALIZATION_DATE({os.getpid()})"]
     simulation_date = config.SimulationDate(2022, 2, 11)
     with pytest.raises(ValueError):
         simulation_date.sim_day

--- a/tests/test_config/test_simulation_date.py
+++ b/tests/test_config/test_simulation_date.py
@@ -28,8 +28,6 @@ def test_simulation_date():
 
 
 def test_simulation_date_without_dynode_flag():
-    # make sure the dynode initialization date flag is not set
-    # del os.environ[f"DYNODE_INITIALIZATION_DATE({os.getpid()})"]
     simulation_date = config.SimulationDate(2022, 2, 11)
     with pytest.raises(ValueError):
         simulation_date.sim_day

--- a/tests/test_config/test_strain.py
+++ b/tests/test_config/test_strain.py
@@ -1,0 +1,87 @@
+import numpyro.distributions as dist
+import pytest
+from pydantic import ValidationError
+
+import dynode.config as config
+
+
+def test_strain():
+    """Test that the Strain config is valid."""
+    try:
+        strain = config.Strain(
+            strain_name="valid_strain", r0=2, infectious_period=5
+        )
+    except ValidationError as e:
+        pytest.fail(f"Strain raised ValidationError unexpectedly: {e}")
+
+    assert strain.strain_name == "valid_strain"
+    assert strain.r0 == 2
+    assert strain.infectious_period == 5
+
+
+# TODO: tests like this fail for now because we have not implemented complex validators
+# capable of checking distribution supports in the case that the r0 is a distribution.
+# def test_invalid_strain_r0():
+#     """Test that the Strain config raises an error for invalid r0."""
+#     with pytest.raises(ValidationError):
+#         config.Strain(strain_name="invalid_strain", r0=-1, infectious_period=5)
+
+
+def test_valid_strain_r0_distribution():
+    """Test that the Strain config accepts a valid r0 distribution."""
+    try:
+        strain = config.Strain(
+            strain_name="valid_strain_dist",
+            r0=dist.Uniform(1.0, 3.0),
+            infectious_period=5,
+        )
+    except ValidationError as e:
+        pytest.fail(f"Strain with r0 distribution raised ValidationError: {e}")
+
+    assert strain.strain_name == "valid_strain_dist"
+    assert isinstance(strain.r0, dist.Distribution)
+    assert strain.infectious_period == 5
+
+
+def test_valid_introduced_strain():
+    """Test that the IntroducedStrain config is valid."""
+    try:
+        introduced_strain = config.Strain(
+            strain_name="introduced_strain",
+            r0=2,
+            infectious_period=5,
+            is_introduced=True,
+            introduction_time=100,
+            introduction_percentage=0.1,
+            introduction_scale=10,
+            introduction_ages=[config.AgeBin(min_value=0, max_value=10)],
+        )
+    except ValidationError as e:
+        pytest.fail(
+            f"IntroducedStrain raised ValidationError unexpectedly: {e}"
+        )
+
+    assert introduced_strain.strain_name == "introduced_strain"
+    assert introduced_strain.is_introduced is True
+    assert introduced_strain.introduction_time == 100
+    assert introduced_strain.introduction_percentage == 0.1
+    assert introduced_strain.introduction_scale == 10
+    assert introduced_strain.introduction_ages == [
+        config.AgeBin(min_value=0, max_value=10)
+    ]
+
+
+# TODO: tests like this fail for now because we have not implemented the validators to check
+# correlated fields like introduction_time, introduction_percentage, etc.
+# def test_partial_introduced_strain():
+#     """Attempt to create a strain that is introduced, but does not have all required fields."""
+#     with pytest.raises(ValidationError):
+#         config.Strain(
+#             strain_name="partial_introduced_strain",
+#             r0=2,
+#             infectious_period=5,
+#             is_introduced=True,
+#             introduction_time=100,
+#             introduction_percentage=0.1,
+#             # Missing introduction_scale and introduction_ages
+#         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,11 +6,6 @@ import numpy as np
 import numpyro.distributions as dist
 
 from dynode import utils
-from dynode.utils import (
-    base_equation,
-    conditional_knots,
-    evaluate_cubic_spline,
-)
 
 # strain indexes {"a": 0, "b": 1, "c": 2}
 
@@ -26,7 +21,7 @@ def test_base_equation():
     coefficients = jnp.array([5, 1, 2, 3])
     tested_times = list(range(-2, 15)) + [100]
     for time in tested_times:
-        assert base_equation(time, coefficients) == equation(time), (
+        assert utils.base_equation(time, coefficients) == equation(time), (
             "base equation failed to evaluate with input : %s" % str(time)
         )
 
@@ -47,7 +42,7 @@ def test_conditional_knots_no_coefficients():
     knots = jnp.array([0, 5, 10])
     tested_times = list(range(-2, 15)) + [100]
     for time in tested_times:
-        assert conditional_knots(time, knots, coefficients) == equation(
+        assert utils.conditional_knots(time, knots, coefficients) == equation(
             time
         ), "conditional_knots failed to evaluate with input : %s" % str(time)
 
@@ -68,7 +63,7 @@ def test_conditional_knots_with_coefficients():
     coefficients = jnp.array([1, 2, 3])
     tested_times = list(range(-2, 15)) + [100]
     for time in tested_times:
-        assert conditional_knots(time, knots, coefficients) == equation(
+        assert utils.conditional_knots(time, knots, coefficients) == equation(
             time
         ), "conditional_knots failed to evaluate with input : %s" % str(time)
 
@@ -92,7 +87,7 @@ def test_cubic_spline():
     knot_coefficients = jnp.array([5, 6, 7])
     tested_times = list(range(-2, 15)) + [100]
     for time in tested_times:
-        assert evaluate_cubic_spline(
+        assert utils.evaluate_cubic_spline(
             time,
             knot_locations,
             base_equation_coefficients,
@@ -128,7 +123,7 @@ def test_evaluate_cubic_spline():
         return base_equation + splines
 
     for t in range(-5, 5, 1):
-        utils_splines = evaluate_cubic_spline(
+        utils_splines = utils.evaluate_cubic_spline(
             t, test_spline_locations, test_base_equations, test_spline_coefs
         ).flatten()
         assert utils_splines[0] == test_spline_1(t), (
@@ -247,3 +242,80 @@ def test_flatten_list_params_multi_dim():
                 4,
                 20,
             ), "flatten_list_parameters breaking up wrong axis when passed >3"
+
+
+def test_vectorize_objects():
+    class TestObject:
+        def __init__(self, value):
+            self.value = value
+
+    objs = [TestObject(i) for i in range(5)]
+    target = "value"
+
+    # Test without filter
+    result = utils.vectorize_objects(objs, target)
+    assert result == [0, 1, 2, 3, 4], "vectorize_objects failed without filter"
+
+    # Test with filter
+    result = utils.vectorize_objects(
+        objs, target, filter=lambda x: x.value > 2
+    )
+    assert result == [3, 4], "vectorize_objects failed with filter"
+
+
+def test_vectorize_objects_exceptions():
+    class TestObject:
+        def __init__(self, value):
+            self.value = value
+
+    objs = [TestObject(i) for i in range(5)]
+    # Test with non-existing attribute
+    try:
+        utils.vectorize_objects(objs, "non_existing")
+    except AttributeError:
+        pass  # Expected behavior
+    else:
+        assert False, "vectorize_objects should raise AttributeError for non-existing attribute"
+
+
+def test_sim_day_to_date():
+    init_date = datetime.date(2022, 10, 15)
+    sim_day = 21
+    expected_date = init_date + datetime.timedelta(days=sim_day)
+
+    result_date = utils.sim_day_to_date(sim_day, init_date)
+
+    assert (
+        result_date == expected_date
+    ), f"sim_day_to_date failed: expected {expected_date}, got {result_date}"
+
+
+def test_sim_day_to_epiweek():
+    # this init_date is on a saturday, which means it still belongs
+    # to the previous year's epi-weeks, thus 52
+    init_date = datetime.date(2022, 1, 1)
+    sim_day = 0
+    epi_week = utils.sim_day_to_epiweek(sim_day, init_date)
+
+    assert (
+        52 == epi_week.week
+    ), f"sim_day_to_epiweek failed: expected 52, got {epi_week.week}"
+    # now lets check the next week, ensuring epi-week wraps back around to 1
+    sim_day = 2
+    epi_week = utils.sim_day_to_epiweek(sim_day, init_date)
+
+    assert (
+        1 == epi_week.week
+    ), f"sim_day_to_epiweek failed: expected 1, got {epi_week.week}"
+
+
+def test_date_to_sim_day():
+    init_date = datetime.date(2022, 10, 15)
+    date = datetime.date(2022, 11, 5)
+    expected_sim_day = (date - init_date).days
+
+    result_sim_day = utils.date_to_sim_day(date, init_date)
+
+    assert (
+        result_sim_day == expected_sim_day
+    ), f"date_to_sim_day failed: expected {expected_sim_day}, got {result_sim_day}"


### PR DESCRIPTION
Added a boat load of unit tests for `dynode.config` submodule. This is not exhaustive and will likely be further expanded in the future

added some very small tests to `dynode.utils` as well but more to come there.

Apologies for the large PR.