### PR TITLE
upgrading pre-commit ruff version to 0.11.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
 #####
 # Python
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.8
+  rev: v0.11.12
   hooks:
     # Sort imports
     - id: ruff

--- a/src/dynode/config/dimension.py
+++ b/src/dynode/config/dimension.py
@@ -60,9 +60,9 @@ class Dimension(BaseModel):
     def _check_bin_names_unique(cls, bins: list[Bin]) -> list[Bin]:
         assert len(bins) > 0, "can not have dimension with no bins"
         names = [b.name for b in bins]
-        assert len(set(names)) == len(
-            names
-        ), "Dimension of categorical bins must have unique bin names."
+        assert len(set(names)) == len(names), (
+            "Dimension of categorical bins must have unique bin names."
+        )
         return bins
 
     @field_validator("bins", mode="after")
@@ -77,9 +77,9 @@ class Dimension(BaseModel):
             bins_sorted = sorted(
                 bins, key=lambda b: b.min_value, reverse=False
             )
-            assert (
-                bins == bins_sorted
-            ), f"Any dimension made up of DiscretizedIntBins must be sorted, got {bins}"
+            assert bins == bins_sorted, (
+                f"Any dimension made up of DiscretizedIntBins must be sorted, got {bins}"
+            )
             # assert that bins dont overlap now they are sorted
             assert all(
                 [
@@ -160,9 +160,9 @@ class FullStratifiedImmuneHistoryDimension(ImmuneHistoryDimension):
         self, strains: list[Strain], name: DynodeName = "hist"
     ) -> None:
         """Create a fully stratified immune history dimension."""
-        assert (
-            len(strains) > 0
-        ), "Must pass at least one strain to immune history dimension."
+        assert len(strains) > 0, (
+            "Must pass at least one strain to immune history dimension."
+        )
         strain_names = [s.strain_name for s in strains]
         all_immune_histories = [Bin(name="none")]
         for strain in range(1, len(strain_names) + 1):
@@ -181,9 +181,9 @@ class LastStrainImmuneHistoryDimension(ImmuneHistoryDimension):
         self, strains: list[Strain], name: DynodeName = "hist"
     ) -> None:
         """Create an immune history dimension that only tracks last infected strain."""
-        assert (
-            len(strains) > 0
-        ), "Must pass at least one strain to immune history dimension."
+        assert len(strains) > 0, (
+            "Must pass at least one strain to immune history dimension."
+        )
         strain_names = [s.strain_name for s in strains]
         bins: list[Bin] = [Bin(name=state) for state in strain_names]
         bins.insert(0, Bin(name="none"))
@@ -211,12 +211,12 @@ class WaneDimension(Dimension):
             name of the dimension, dimensions tracking different waning states
             must have different names, by default "wane".
         """
-        assert (
-            len(waiting_times) > 0
-        ), "Wane dimension must have at least one bin."
-        assert len(waiting_times) == len(
-            base_protections
-        ), "must pass equal length wait times and base protections"
+        assert len(waiting_times) > 0, (
+            "Wane dimension must have at least one bin."
+        )
+        assert len(waiting_times) == len(base_protections), (
+            "must pass equal length wait times and base protections"
+        )
         bins: list[Bin] = []
         for idx, (wait_time, base_protection) in enumerate(
             zip(waiting_times, base_protections)
@@ -238,7 +238,7 @@ class WaneDimension(Dimension):
         """Validate last wane bin can not be waned out of."""
         last_wane_bin = self.bins[-1]
         assert isinstance(last_wane_bin, WaneBin)
-        assert isinf(
-            last_wane_bin.waiting_time
-        ), "last wane bin should have math.inf waiting time"
+        assert isinf(last_wane_bin.waiting_time), (
+            "last wane bin should have math.inf waiting time"
+        )
         return self

--- a/src/dynode/config/params.py
+++ b/src/dynode/config/params.py
@@ -123,7 +123,9 @@ class TransmissionParams(BaseModel):
         ]
         assert all(
             [compare == strain_intro_ages[0] for compare in strain_intro_ages]
-        ), "currently DynODE requires all strains have matching introduction_ages."
+        ), (
+            "currently DynODE requires all strains have matching introduction_ages."
+        )
         # Fields to check for consistency (excluding introduction_* fields)
         optional_fields_to_check = [
             "exposed_to_infectious",

--- a/src/dynode/config/simulation_config.py
+++ b/src/dynode/config/simulation_config.py
@@ -64,9 +64,9 @@ class Compartment(BaseModel):
     def _validate_dimensions_names(self):
         """Assert that all dimensions in the Compartment have unique names."""
         dimension_names = [dim.name for dim in self.dimensions]
-        assert (
-            len(set(dimension_names)) == len(dimension_names)
-        ), "you can not have two identically named dimensions within a compartment"
+        assert len(set(dimension_names)) == len(dimension_names), (
+            "you can not have two identically named dimensions within a compartment"
+        )
         return self
 
     @property
@@ -260,9 +260,9 @@ class SimulationConfig(BaseModel):
                     LastStrainImmuneHistoryDimension,
                 ),
             )
-            assert (
-                type(dimension)(strains) == dimension
-            ), "Found immune states that dont correlate with strains from transmission_params"
+            assert type(dimension)(strains) == dimension, (
+                "Found immune states that dont correlate with strains from transmission_params"
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/dynode/simulation/odes.py
+++ b/src/dynode/simulation/odes.py
@@ -107,9 +107,9 @@ def simulate(
     term = ODETerm(ode)
     t0 = 0.0
     dt0 = None  # first step size determined automatically
-    assert isinstance(
-        duration_days, (int, float)
-    ), "tf must be of type int or float"
+    assert isinstance(duration_days, (int, float)), (
+        "tf must be of type int or float"
+    )
 
     stepsize_controller: AbstractStepSizeController
     if solver_parameters.constant_step_size > 0.0:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -169,9 +169,9 @@ def test_identify_distribution_indexes():
         "sample_name": "example",
         "sample_idx": None,
     }, "not correctly indexing non-list sampled parameters"
-    assert (
-        "no-sample" not in indexes.keys()
-    ), "identify_distribution_indexes should not return indexes for unsampled parameters"
+    assert "no-sample" not in indexes.keys(), (
+        "identify_distribution_indexes should not return indexes for unsampled parameters"
+    )
 
 
 # get the function to test
@@ -202,9 +202,9 @@ def test_flatten_list_params_numpy():
     assert "test" not in flattened.keys()
     for suffix in range(5):
         key = "test_%s" % str(suffix)
-        assert (
-            key in flattened.keys()
-        ), "flatten_list_parameters not naming split params correctly."
+        assert key in flattened.keys(), (
+            "flatten_list_parameters not naming split params correctly."
+        )
         assert flattened[key].shape == (
             4,
             20,
@@ -219,9 +219,9 @@ def test_flatten_list_params_jax_numpy():
     assert "test" not in flattened.keys()
     for suffix in range(5):
         key = "test_%s" % str(suffix)
-        assert (
-            key in flattened.keys()
-        ), "flatten_list_parameters not naming split params correctly."
+        assert key in flattened.keys(), (
+            "flatten_list_parameters not naming split params correctly."
+        )
         assert flattened[key].shape == (
             4,
             20,
@@ -240,9 +240,9 @@ def test_flatten_list_params_multi_dim():
                 str(suffix_first_dim),
                 str(suffix_second_dim),
             )
-            assert (
-                key in flattened.keys()
-            ), "flatten_list_parameters not naming split params correctly."
+            assert key in flattened.keys(), (
+                "flatten_list_parameters not naming split params correctly."
+            )
             assert flattened[key].shape == (
                 4,
                 20,


### PR DESCRIPTION
This upgrade is to be in line with ruff version on the VScode extension, this way developers dont need to download a needlessly downgraded version of ruff locally in order to avoid a formatting mismatch.

any code changes you see to this PR dont impact functionality and are a result of upgrading the code formatter.