### PR TITLE
expose `_prefix` in `sample_then_resolve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ on a given day. The `micro` version is suffixed with an `a` in the case of mergi
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
 
+## [2025.07.12.1a] - expose `_prefix` in `sample_then_resolve`
+### Changed
+- exposed a `_prefix` parameter to `sample_then_resolve` to allow users to add custom prefixes to their sampled/resolved parameters
+
 ## [2025.06.26.1a] - remove `.values` field from `Compartment`
 ### Removed
 - `.values` field from `Compartment` class, as it was not used anywhere in the codebase and was causing confusion for users. The `Compartment` class now only contains the wireframe of the compartment sizes, but the values themselves are stored in the `diffrax.Solution` object returned by the `dynode.simulate()` function. We should discorage users from accessing the `.values` field of `Compartment` objects directly, except for in the ODEs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynode"
-version = "2025.06.26.1a"
+version = "2025.07.12.1a"
 description = "CDC CFA Predict Scenarios model development"
 authors = ["CFA"]
 license = "Apache License, Version 2.0, January 2004"

--- a/src/dynode/infer/sample.py
+++ b/src/dynode/infer/sample.py
@@ -15,7 +15,9 @@ from pydantic import BaseModel
 import dynode.config
 
 
-def sample_distributions(obj: Any, rng_key: Array | None = None, _prefix: str = ""):
+def sample_distributions(
+    obj: Any, rng_key: Array | None = None, _prefix: str = ""
+):
     """Recurisvely scans data structures and samples numpyro.Distribution objects.
 
     Parameters
@@ -51,11 +53,17 @@ def sample_distributions(obj: Any, rng_key: Array | None = None, _prefix: str = 
             obj_dict[key] = sample_distributions(
                 value, rng_key=rng_key, _prefix=_prefix + f"{key}_"
             )
-        return dict(obj_dict) if isinstance(obj, dict) else obj.__class__(**obj_dict)
+        return (
+            dict(obj_dict)
+            if isinstance(obj, dict)
+            else obj.__class__(**obj_dict)
+        )
     elif isinstance(obj, (np.ndarray, list)):
         # Recursively sample elements in list.
         lst = [
-            sample_distributions(item, rng_key=rng_key, _prefix=_prefix + f"{i}_")
+            sample_distributions(
+                item, rng_key=rng_key, _prefix=_prefix + f"{i}_"
+            )
             for i, item in enumerate(obj)
         ]
 
@@ -71,7 +79,9 @@ def sample_distributions(obj: Any, rng_key: Array | None = None, _prefix: str = 
         return obj
 
 
-def resolve_deterministic(obj: Any, root_params: dict | BaseModel, _prefix: str = ""):
+def resolve_deterministic(
+    obj: Any, root_params: dict | BaseModel, _prefix: str = ""
+):
     """Find and resolve all DeterministicParameter types.
 
     Parameters
@@ -126,7 +136,11 @@ def resolve_deterministic(obj: Any, root_params: dict | BaseModel, _prefix: str 
             obj_dict[key] = resolve_deterministic(
                 value, root_params, _prefix=_prefix + f"{key}_"
             )
-        return dict(obj_dict) if isinstance(obj, dict) else obj.__class__(**obj_dict)
+        return (
+            dict(obj_dict)
+            if isinstance(obj, dict)
+            else obj.__class__(**obj_dict)
+        )
     elif isinstance(obj, (np.ndarray, list)):
         # Recursively sample elements in list.
         return [
@@ -174,7 +188,9 @@ def sample_then_resolve(
         with samples / resolved values.
     """
     parameters = deepcopy(parameters)
-    parameters = sample_distributions(parameters, rng_key=rng_key, _prefix=_prefix)
+    parameters = sample_distributions(
+        parameters, rng_key=rng_key, _prefix=_prefix
+    )
     parameters = resolve_deterministic(
         parameters, root_params=dict(parameters), _prefix=_prefix
     )

--- a/tests/test_infer/test_sample.py
+++ b/tests/test_infer/test_sample.py
@@ -53,19 +53,21 @@ def test_sample_distributions_naming():
         "c": np.array([dist.Normal(), 1]),
         "d": {"nested_dict": dist.Normal()},
     }
-    t = trace(lambda: sample_distributions(test, rng_key=PRNGKey(0))).get_trace()
-    assert (
-        "a" in t.keys()
-    ), f"{test} samples not named correctly, expected 'a', got {t.keys()}"
-    assert (
-        "b_1" in t.keys()
-    ), f"{test} samples not named correctly, expected 'b_1', got {t.keys()}"
-    assert (
-        "c_0" in t.keys()
-    ), f"{test} samples not named correctly, expected 'c_0', got {t.keys()}"
-    assert (
-        "d_nested_dict" in t.keys()
-    ), f"{test} samples not named correctly, expected 'd_nested_dict', got {t.keys()}"
+    t = trace(
+        lambda: sample_distributions(test, rng_key=PRNGKey(0))
+    ).get_trace()
+    assert "a" in t.keys(), (
+        f"{test} samples not named correctly, expected 'a', got {t.keys()}"
+    )
+    assert "b_1" in t.keys(), (
+        f"{test} samples not named correctly, expected 'b_1', got {t.keys()}"
+    )
+    assert "c_0" in t.keys(), (
+        f"{test} samples not named correctly, expected 'c_0', got {t.keys()}"
+    )
+    assert "d_nested_dict" in t.keys(), (
+        f"{test} samples not named correctly, expected 'd_nested_dict', got {t.keys()}"
+    )
 
 
 def test_sample_distributions_naming_prefix():
@@ -78,18 +80,18 @@ def test_sample_distributions_naming_prefix():
     t = trace(
         lambda: sample_distributions(test, rng_key=PRNGKey(0), _prefix="test_")
     ).get_trace()
-    assert (
-        "test_a" in t.keys()
-    ), f"{test} samples not named correctly, expected 'a', got {t.keys()}"
-    assert (
-        "test_b_1" in t.keys()
-    ), f"{test} samples not named correctly, expected 'b_1', got {t.keys()}"
-    assert (
-        "test_c_0" in t.keys()
-    ), f"{test} samples not named correctly, expected 'c_0', got {t.keys()}"
-    assert (
-        "test_d_nested_dict" in t.keys()
-    ), f"{test} samples not named correctly, expected 'd_nested_dict', got {t.keys()}"
+    assert "test_a" in t.keys(), (
+        f"{test} samples not named correctly, expected 'a', got {t.keys()}"
+    )
+    assert "test_b_1" in t.keys(), (
+        f"{test} samples not named correctly, expected 'b_1', got {t.keys()}"
+    )
+    assert "test_c_0" in t.keys(), (
+        f"{test} samples not named correctly, expected 'c_0', got {t.keys()}"
+    )
+    assert "test_d_nested_dict" in t.keys(), (
+        f"{test} samples not named correctly, expected 'd_nested_dict', got {t.keys()}"
+    )
 
 
 def test_resolve_deterministic():
@@ -132,18 +134,18 @@ def test_sample_then_resolve_naming_prefix():
     t = trace(
         lambda: sample_then_resolve(test, rng_key=PRNGKey(0), _prefix="test_"),
     ).get_trace()
-    assert (
-        "test_a" in t.keys()
-    ), f"{test} samples not named correctly, expected 'test_a', got {t.keys()}"
-    assert (
-        "test_b_1" in t.keys()
-    ), f"{test} samples not named correctly, expected 'test_b_1', got {t.keys()}"
-    assert (
-        "test_c_0" in t.keys()
-    ), f"{test} samples not named correctly, expected 'test_c_0', got {t.keys()}"
-    assert (
-        "test_d_nested_dict" in t.keys()
-    ), f"{test} samples not named correctly, expected 'test_d_nested_dict', got {t.keys()}"
-    assert (
-        "test_e" in t.keys()
-    ), f"{test} samples not named correctly, expected 'test_e', got {t.keys()}"
+    assert "test_a" in t.keys(), (
+        f"{test} samples not named correctly, expected 'test_a', got {t.keys()}"
+    )
+    assert "test_b_1" in t.keys(), (
+        f"{test} samples not named correctly, expected 'test_b_1', got {t.keys()}"
+    )
+    assert "test_c_0" in t.keys(), (
+        f"{test} samples not named correctly, expected 'test_c_0', got {t.keys()}"
+    )
+    assert "test_d_nested_dict" in t.keys(), (
+        f"{test} samples not named correctly, expected 'test_d_nested_dict', got {t.keys()}"
+    )
+    assert "test_e" in t.keys(), (
+        f"{test} samples not named correctly, expected 'test_e', got {t.keys()}"
+    )

--- a/tests/test_infer/test_sample.py
+++ b/tests/test_infer/test_sample.py
@@ -53,21 +53,43 @@ def test_sample_distributions_naming():
         "c": np.array([dist.Normal(), 1]),
         "d": {"nested_dict": dist.Normal()},
     }
+    t = trace(lambda: sample_distributions(test, rng_key=PRNGKey(0))).get_trace()
+    assert (
+        "a" in t.keys()
+    ), f"{test} samples not named correctly, expected 'a', got {t.keys()}"
+    assert (
+        "b_1" in t.keys()
+    ), f"{test} samples not named correctly, expected 'b_1', got {t.keys()}"
+    assert (
+        "c_0" in t.keys()
+    ), f"{test} samples not named correctly, expected 'c_0', got {t.keys()}"
+    assert (
+        "d_nested_dict" in t.keys()
+    ), f"{test} samples not named correctly, expected 'd_nested_dict', got {t.keys()}"
+
+
+def test_sample_distributions_naming_prefix():
+    test = {
+        "a": dist.Normal(),
+        "b": [1, dist.Normal()],
+        "c": np.array([dist.Normal(), 1]),
+        "d": {"nested_dict": dist.Normal()},
+    }
     t = trace(
-        lambda: sample_distributions(test, rng_key=PRNGKey(0))
+        lambda: sample_distributions(test, rng_key=PRNGKey(0), _prefix="test_")
     ).get_trace()
-    assert "a" in t.keys(), (
-        f"{test} samples not named correctly, expected 'a', got {t.keys()}"
-    )
-    assert "b_1" in t.keys(), (
-        f"{test} samples not named correctly, expected 'b_1', got {t.keys()}"
-    )
-    assert "c_0" in t.keys(), (
-        f"{test} samples not named correctly, expected 'c_0', got {t.keys()}"
-    )
-    assert "d_nested_dict" in t.keys(), (
-        f"{test} samples not named correctly, expected 'd_nested_dict', got {t.keys()}"
-    )
+    assert (
+        "test_a" in t.keys()
+    ), f"{test} samples not named correctly, expected 'a', got {t.keys()}"
+    assert (
+        "test_b_1" in t.keys()
+    ), f"{test} samples not named correctly, expected 'b_1', got {t.keys()}"
+    assert (
+        "test_c_0" in t.keys()
+    ), f"{test} samples not named correctly, expected 'c_0', got {t.keys()}"
+    assert (
+        "test_d_nested_dict" in t.keys()
+    ), f"{test} samples not named correctly, expected 'd_nested_dict', got {t.keys()}"
 
 
 def test_resolve_deterministic():
@@ -97,3 +119,31 @@ def test_sample_then_resolve():
     assert isinstance(test["a"], Array)
     assert isinstance(test["b"], Array)
     assert test["a"] == test["b"]
+
+
+def test_sample_then_resolve_naming_prefix():
+    test = {
+        "a": dist.Normal(),
+        "b": [1, dist.Normal()],
+        "c": np.array([dist.Normal(), 1]),
+        "d": {"nested_dict": dist.Normal()},
+        "e": DeterministicParameter("a"),
+    }
+    t = trace(
+        lambda: sample_then_resolve(test, rng_key=PRNGKey(0), _prefix="test_"),
+    ).get_trace()
+    assert (
+        "test_a" in t.keys()
+    ), f"{test} samples not named correctly, expected 'test_a', got {t.keys()}"
+    assert (
+        "test_b_1" in t.keys()
+    ), f"{test} samples not named correctly, expected 'test_b_1', got {t.keys()}"
+    assert (
+        "test_c_0" in t.keys()
+    ), f"{test} samples not named correctly, expected 'test_c_0', got {t.keys()}"
+    assert (
+        "test_d_nested_dict" in t.keys()
+    ), f"{test} samples not named correctly, expected 'test_d_nested_dict', got {t.keys()}"
+    assert (
+        "test_e" in t.keys()
+    ), f"{test} samples not named correctly, expected 'test_e', got {t.keys()}"


### PR DESCRIPTION
Exposed a `_prefix` parameter to `sample_then_resolve` to allow users to add custom prefixes to their sampled/resolved parameters.

just an open source contributor passing through :)

CLOSES #449 