### PR TITLE
Fix downstream issues with messing with `pyproject.toml`

### DIFF
--- a/.github/workflows/tagging.yaml
+++ b/.github/workflows/tagging.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Get version from pyproject.toml
         id: get_version
         run: |
-          VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['tool']['poetry']['version'])")
+          VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Create Tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ pattern: `YYYY.MM.DD.micro`, where `micro` monotonically increases with each PR 
 on a given day. The `micro` version is suffixed with an `a` in the case of merging to `main` or
 `development` branches, a `b` when starting the release process in the staging branch, and
 no suffix when releases and the staging branch is pulled into the release branch.
+## [2026.06.24.1a] - fix downstream issues of tagging/doc-generating failure
+### Changed
+- Adding back dependencies for `sphinx` in `pyproject.toml`
+- Modified `.github/tagging.yaml` and `docs/source/conf.py` to accommodate changes in pyproject.
+
 ## [2026.06.02.1a] - changing dependencies allowing upgrade of python version
 ### Changed
 - Allowed later version of python from 3.10 up to 3.13 in `pyproject.toml`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,9 +16,9 @@ with open("../../pyproject.toml", "rb") as file:
     pyproject_data = tomli.load(file)
 
 project = "DynODE"
-copyright = pyproject_data["tool"]["poetry"]["license"]
-author = "".join(pyproject_data["tool"]["poetry"]["authors"])
-release = pyproject_data["tool"]["poetry"]["version"]
+copyright = pyproject_data["project"]["license"]
+author = ", ".join(d["name"] for d in pyproject_data["project"]["authors"])
+release = pyproject_data["project"]["version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ chex = {git = "https://github.com/mishmish66/chex.git", rev="6c9f2fb727ba3854745
 arviz = ">=0.21,<0.23.4"
 typing-extensions = ">=4.13.2"
 annotated-types = ">=0.7.0"
-#sphinx = ">=8.2.3"
+sphinx = "<8.2.3"
 sphinx-book-theme = ">=1.1.4"
-#tomli = "^2.2.1"
-myst-parser = "^4.0.1"
+tomli = ">=2.2.1"
+myst-parser = ">=4.0.1"
 sphinxcontrib-mermaid = ">=1.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dynode"
-version = "2026.06.02.1a"
+version = "2026.06.24.1a"
 description = "CDC CFA Predict Scenarios model development"
 authors = [{name="CFA"}]
 license = "Apache License, Version 2.0, January 2004"


### PR DESCRIPTION
Messing around with `pyproject.toml` has unanticipated issues with github workflows 😶

Specifically:
* `[tool.poetry]` is deprecated with `pyproject.toml` so I changed it to `[project]`
* But as a result, it breaks tagging and sphinx-build
* On top of that I also removed `sphinx` dependencies in previous PR...

Modified tagging and doc building script to accommodate `pyproject.toml` changes, also added back `sphinx` and `tomli` dependencies.
`sphinx` dependency will be interesting down the road as it no longer supports python 3.10 from 8.1.3 onwards 🤔